### PR TITLE
Support Cuda 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@
 ARG LIBXRENDER_VERSION=1:0.9.10-*
 ARG LIBXEXT_VERSION=2:1.3.4-*
 
-FROM docker.io/nvidia/cuda:12.4.1-devel-ubuntu20.04 AS tmd_base_env
+FROM docker.io/nvidia/cuda:13.0.2-devel-ubuntu24.04 AS tmd_base_env
 ARG LIBXRENDER_VERSION
 ARG LIBXEXT_VERSION
 
 # Copied out of anaconda's dockerfile
-ARG GIT_VERSION=1:2.25.1-*
-ARG WGET_VERSION=1.20.3-*
+ARG MAKE_VERSION=4.3-*
+ARG GIT_VERSION=1:2.43.0-*
+ARG WGET_VERSION=1.21.4-*
 RUN (apt-get update || true)  && apt-get install --no-install-recommends -y \
-    wget=${WGET_VERSION} git=${GIT_VERSION} libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \
+    wget=${WGET_VERSION} git=${GIT_VERSION} make=${MAKE_VERSION} libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -73,7 +74,7 @@ RUN find /usr/local/cuda/targets/x86_64-linux/lib/ -regextype posix-extended -ty
 
 # Container with only cuda base, half the size of the tmd_cuda_dev container
 # Need to copy curand/cudart as these are dependencies of the TMD GPU code
-FROM docker.io/nvidia/cuda:12.4.1-base-ubuntu20.04 AS tmd
+FROM docker.io/nvidia/cuda:13.0.2-base-ubuntu24.04 AS tmd
 ARG LIBXRENDER_VERSION
 ARG LIBXEXT_VERSION
 RUN (apt-get update || true) && apt-get install --no-install-recommends -y libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@
 ARG LIBXRENDER_VERSION=1:0.9.10-*
 ARG LIBXEXT_VERSION=2:1.3.4-*
 
-FROM docker.io/nvidia/cuda:13.0.2-devel-ubuntu24.04 AS tmd_base_env
+FROM docker.io/nvidia/cuda:12.4.1-devel-ubuntu20.04 AS tmd_base_env
 ARG LIBXRENDER_VERSION
 ARG LIBXEXT_VERSION
 
 # Copied out of anaconda's dockerfile
-ARG MAKE_VERSION=4.3-*
-ARG GIT_VERSION=1:2.43.0-*
-ARG WGET_VERSION=1.21.4-*
+ARG GIT_VERSION=1:2.25.1-*
+ARG WGET_VERSION=1.20.3-*
 RUN (apt-get update || true)  && apt-get install --no-install-recommends -y \
-    wget=${WGET_VERSION} git=${GIT_VERSION} make=${MAKE_VERSION} libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \
+    wget=${WGET_VERSION} git=${GIT_VERSION} libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -74,7 +73,7 @@ RUN find /usr/local/cuda/targets/x86_64-linux/lib/ -regextype posix-extended -ty
 
 # Container with only cuda base, half the size of the tmd_cuda_dev container
 # Need to copy curand/cudart as these are dependencies of the TMD GPU code
-FROM docker.io/nvidia/cuda:13.0.2-base-ubuntu24.04 AS tmd
+FROM docker.io/nvidia/cuda:12.4.1-base-ubuntu20.04 AS tmd
 ARG LIBXRENDER_VERSION
 ARG LIBXEXT_VERSION
 RUN (apt-get update || true) && apt-get install --no-install-recommends -y libxrender1=${LIBXRENDER_VERSION} libxext-dev=${LIBXEXT_VERSION} \

--- a/tmd/cpp/CMakeLists.txt
+++ b/tmd/cpp/CMakeLists.txt
@@ -148,6 +148,11 @@ pybind11_add_module(${LIBRARY_NAME} SHARED NO_EXTRAS
 
 include_directories(src/kernels)
 include_directories(SYSTEM ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+# To handle inporting CCCL library headers in the host code (ie compiled by GCC), need to include CCCL directory
+# See https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html#cuda-toolkit-changes
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")
+  include_directories(SYSTEM ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cccl/)
+endif()
 include_directories(SYSTEM ${CMAKE_CURRENT_BINARY_DIR}/${EIGEN_SRC_DIR})
 
 set_property(TARGET ${LIBRARY_NAME} PROPERTY CUDA_STANDARD 17)


### PR DESCRIPTION
* Cuda 13 has some faster math operations: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-math-release-13-0
* Failed to build due to CCCL libraries being moved
* Unlike https://github.com/tmd-industries/tmd/pull/49 doesn't make any docker changes