### PR TITLE
Bump to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.tbump.version]
-current = "0.3.4"
+current = "0.4.0"
 
 regex = '''
   (?P<major>\d+)

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ if install_custom_ops():
 
 setup(
     name="tmd",
-    version="0.3.4",
+    version="0.4.0",
     cmdclass={"build_ext": CMakeBuild},
     description="A high-performance differentiable molecular dynamics and optimization engine",
     long_description=long_description,

--- a/tmd/__init__.py
+++ b/tmd/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-__version__ = "0.3.4"
+__version__ = "0.4.0"
 
 
 def _suppress_jax_no_gpu_warning():


### PR DESCRIPTION
* A minor version update to account for the change in the electrostatics representation from a custom switching function to a standard tinfoil rxn field implementation