### PR TITLE
Improve ABFE protocol

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -371,12 +371,12 @@ def test_run_abfe(
 ):
     leg_results_hashes = {
         "solvent": (
-            "e759e03ef2c0f77bce80c69efe8115f498b538b08770bb743a112979e269014b",
-            "40260a127f1b2c5bbba09297245440d699e7220485618220d99a27407c1fefa8",
+            "220a0ddf08d3677c028d6ab12bb210bc7e6825e0fbeb575824b9b0f3044c1bcf",
+            "90846a75884a668c5de0ddf14776b3266a037988c9cc049a8fbb011db810e40b",
         ),
         "complex": (
-            "b406a8d1dde016ba2039969f018d348fb94f8e2383617e5f241fd04565847e15",
-            "3becf5e6d398d2c2599ba03e024a33c9e43b19397acb0f01234173cd34f4aee2",
+            "e1dc85cb2cf22fecfdbd403e57144f9a9e0e6146bc5f78bd5eba826d25fff9c0",
+            "2e8ce51a4f0c99c0c2eb13500a9f64809a355917a76eb91b08e7eb918143be1a",
         ),
     }
 

--- a/tests/test_minimizer.py
+++ b/tests/test_minimizer.py
@@ -419,7 +419,7 @@ def test_local_minimize_restrained_waters_trigger_failure(seed, minimizer_config
     ff = Forcefield.load_from_file("smirnoff_2_0_0_sc.py")
 
     # Use non-zero lambda to ensure forces are large to start
-    lamb = 0.1
+    lamb = 0.15
 
     # Setup a water box without a void for the mol
     host_config = builders.build_water_system(4.0, ff.water_ff, box_margin=0.1)

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -586,7 +586,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         combined_params, combined_potentials = self._get_system_params_and_potentials(ff_params, hgt, lamb)
         combined_params = list(combined_params)
         if lamb > 0.0:
-            # Linearly decharge the ligand from lamb 0.0 -> 0.4
+            # Linearly decharge the ligand from lamb 0.0 -> 0.15
             nb_params_idx = next(i for i, pot in enumerate(combined_potentials) if isinstance(pot, Nonbonded))
             nb_params = combined_params[nb_params_idx]
             nb_params = nb_params.at[len(host_config.conf) :, NBParamIdx.Q_IDX].set(
@@ -596,7 +596,18 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
                     np.zeros_like(nb_params[len(host_config.conf) :, NBParamIdx.Q_IDX]),
                     lamb,
                     0.0,
-                    0.4,
+                    0.15,
+                )
+            )
+            dst_eps = nb_params[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX] / 3
+            nb_params = nb_params.at[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX].set(
+                pad(
+                    linear_interpolation,
+                    nb_params[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX],
+                    np.where(dst_eps > 0.02, dst_eps, 0.02),
+                    lamb,
+                    0.0,
+                    0.25,
                 )
             )
             combined_params[nb_params_idx] = nb_params  # type: ignore

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -23,6 +23,7 @@ from warnings import warn
 import jax
 import numpy as np
 from numpy.typing import NDArray
+from rdkit import Chem
 
 from tmd._vendored.pymbar.utils import kln_to_kn
 from tmd.constants import BOLTZ, NBParamIdx
@@ -538,7 +539,13 @@ class BaseFreeEnergy:
 # this class is serializable.
 # DEBOGGLE: Move this to tmd.fe.absolute.free_energy
 class AbsoluteFreeEnergy(BaseFreeEnergy):
-    def __init__(self, mol, top):
+    def __init__(
+        self,
+        mol: Chem.Mol,
+        top,
+        decharge_interval: tuple[float, float] = (0.0, 0.2),
+        eps_scale_interval: tuple[float, float] = (0.2, 0.4),
+    ):
         """
         Compute the absolute free energy of a molecule via 4D decoupling.
 
@@ -550,9 +557,26 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         top: Topology
             topology.Topology to use
 
+        decharge_interval: tuple[float, float]
+            Interval over which the ligand intermolecular charge is decharged over. Only intended for testing, suggested not to edge.
+        eps_scale_interval: tuple[float, float]
+            Interval over which the ligand intermolecular epsilon is scaled down over. Only intended for testing, suggested not to edge.
+
         """
         self.mol = mol
         self.top = top
+
+        def verify_interval(interval):
+            assert len(interval) == 2
+            assert interval[0] < interval[1]
+            assert interval[0] >= 0.0
+            assert interval[1] <= 1.0
+
+        verify_interval(decharge_interval)
+        verify_interval(eps_scale_interval)
+
+        self.decharge_interval = decharge_interval
+        self.eps_scale_interval = eps_scale_interval
 
     def prepare_host_edge(
         self, ff: Forcefield, host_config: HostConfig, lamb: float
@@ -595,8 +619,8 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
                     nb_params[len(host_config.conf) :, NBParamIdx.Q_IDX],
                     np.zeros_like(nb_params[len(host_config.conf) :, NBParamIdx.Q_IDX]),
                     lamb,
-                    0.0,
-                    0.2,
+                    self.decharge_interval[0],
+                    self.decharge_interval[1],
                 )
             )
             # Scale down the epsilon term
@@ -607,8 +631,8 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
                     nb_params[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX],
                     np.where(dst_eps > 0.02, dst_eps, 0.02),
                     lamb,
-                    0.2,
-                    0.4,
+                    self.eps_scale_interval[0],
+                    self.eps_scale_interval[1],
                 )
             )
 

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -36,7 +36,7 @@ from tmd.fe.bar import (
     works_from_ukln,
 )
 from tmd.fe.interpolate import linear_interpolation, pad
-from tmd.fe.lambda_schedule import interpolate_pre_optimized_protocol
+from tmd.fe.lambda_schedule import construct_pre_optimized_relative_lambda_schedule, interpolate_pre_optimized_protocol
 from tmd.fe.plots import (
     plot_as_png_fxn,
     plot_dG_errs_figure,
@@ -596,7 +596,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
                     np.zeros_like(nb_params[len(host_config.conf) :, NBParamIdx.Q_IDX]),
                     lamb,
                     0.0,
-                    0.15,
+                    0.2,
                 )
             )
             dst_eps = nb_params[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX] / 3
@@ -606,9 +606,16 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
                     nb_params[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX],
                     np.where(dst_eps > 0.02, dst_eps, 0.02),
                     lamb,
-                    0.0,
-                    0.25,
+                    0.2,
+                    0.4,
                 )
+            )
+
+            # Shift the W coordinate to improve efficiency
+            lambdas = construct_pre_optimized_relative_lambda_schedule(None)
+            x = np.linspace(0.0, 1.0, len(lambdas))
+            nb_params = nb_params.at[len(host_config.conf) :, NBParamIdx.W_IDX].set(
+                linear_interpolation(0.0, hgt.host_nonbonded.potential.cutoff, np.interp(lamb, x, lambdas))
             )
             combined_params[nb_params_idx] = nb_params  # type: ignore
 

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -586,7 +586,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
         combined_params, combined_potentials = self._get_system_params_and_potentials(ff_params, hgt, lamb)
         combined_params = list(combined_params)
         if lamb > 0.0:
-            # Linearly decharge the ligand from lamb 0.0 -> 0.15
+            # Linearly decharge the ligand
             nb_params_idx = next(i for i, pot in enumerate(combined_potentials) if isinstance(pot, Nonbonded))
             nb_params = combined_params[nb_params_idx]
             nb_params = nb_params.at[len(host_config.conf) :, NBParamIdx.Q_IDX].set(
@@ -599,6 +599,7 @@ class AbsoluteFreeEnergy(BaseFreeEnergy):
                     0.2,
                 )
             )
+            # Scale down the epsilon term
             dst_eps = nb_params[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX] / 3
             nb_params = nb_params.at[len(host_config.conf) :, NBParamIdx.LJ_EPS_IDX].set(
                 pad(


### PR DESCRIPTION
Previous the protocol has severe bottlenecks in the complex leg due to poor W coordinate interpolation.

## Previous JNK1 (18628-1_flip)
<img width="1130" height="985" alt="hrex_replica_state_distribution_heatmap" src="https://github.com/user-attachments/assets/373ae99c-56d2-4bdd-90b6-9f773f311a12" />

## New JNK1 (18628-1_flip)
<img width="1128" height="985" alt="hrex_replica_state_distribution_heatmap" src="https://github.com/user-attachments/assets/7e125ba1-dbef-48eb-8773-37b90b30fdd7" />


## SHP2 Results

Command: `TMD_BATCH_MODE=on python tmd/examples/run_abfe.py --forcefield smirnoff_2_2_1_amber_am1bcc.py --sdf_path rbfe-datasets/datasets/merck/shp2/ligands.sdf --pdb_path rbfe-datasets/datasets/merck/shp2/shp2_structure.pdb --local_md_steps 390 --seed 548 --mps_workers 2 --n_gpus 1 --legs complex solvent --output_dir retrospective_sets/abfe_shp2`

<img width="977" height="678" alt="image" src="https://github.com/user-attachments/assets/03fd2627-4be7-4a21-9fbe-06f821fcc729" />
