### PR TITLE
Add option to enable multiple iterations of local MD

### DIFF
--- a/examples/run_abfe.py
+++ b/examples/run_abfe.py
@@ -431,15 +431,23 @@ def main():
         "--output_dir", default=None, help="Directory to output results, else generates a directory based on the time"
     )
     parser.add_argument("--legs", default=[COMPLEX_LEG, SOLVENT_LEG], nargs="+")
+    parser.add_argument(
+        "--bisection_frames", type=int, default=100, help="Number of frames to collect during bisection"
+    )
     parser.add_argument("--local_md_k", default=10_000.0, type=float, help="Local MD k parameter")
     parser.add_argument("--local_md_radius", default=1.2, type=float, help="Local MD radius")
     parser.add_argument("--local_md_free_reference", action="store_true")
-    parser.add_argument("--bisection_frames", type=int, default=100)
     parser.add_argument(
         "--local_md_steps",
         default=0,
         type=int,
         help="Number of steps to run with Local MD. Must be less than or equal to --steps_per_frame. If set to 0, no local MD is run",
+    )
+    parser.add_argument(
+        "--local_md_iterations",
+        default=1,
+        type=int,
+        help="Number of independent local MD iterations to make. local_md_steps // local_md_iterations steps per iteration",
     )
     parser.add_argument(
         "--store_trajectories",
@@ -521,6 +529,7 @@ def main():
                 min_radius=args.local_md_radius,
                 max_radius=args.local_md_radius,
                 freeze_reference=not args.local_md_free_reference,
+                iterations=args.local_md_iterations,
             )
             if args.local_md_steps > 0
             else None,

--- a/examples/run_rbfe_graph.py
+++ b/examples/run_rbfe_graph.py
@@ -88,6 +88,12 @@ def main():
         help="Number of steps to run with Local MD. Must be less than or equal to --steps_per_frame. If set to 0, no local MD is run",
     )
     parser.add_argument(
+        "--local_md_iterations",
+        default=1,
+        type=int,
+        help="Number of independent local MD iterations to make. local_md_steps // local_md_iterations steps per iteration",
+    )
+    parser.add_argument(
         "--store_trajectories",
         action="store_true",
         help="Store the trajectories of the edges. Can take up a large amount of space",
@@ -192,6 +198,7 @@ def main():
                 min_radius=args.local_md_radius,
                 max_radius=args.local_md_radius,
                 freeze_reference=not args.local_md_free_reference,
+                iterations=args.local_md_iterations,
             )
             if args.local_md_steps > 0
             else None,

--- a/examples/run_rbfe_legs.py
+++ b/examples/run_rbfe_legs.py
@@ -102,6 +102,12 @@ def main():
         help="Number of steps to run with Local MD. Must be less than or equal to --steps_per_frame. If set to 0, no local MD is run",
     )
     parser.add_argument(
+        "--local_md_iterations",
+        default=1,
+        type=int,
+        help="Number of independent local MD iterations to make. local_md_steps // local_md_iterations steps per iteration",
+    )
+    parser.add_argument(
         "--serial", action="store_true", help="Run without spawning subprocesses, useful when wanting to profile."
     )
     parser.add_argument(
@@ -170,7 +176,11 @@ def main():
             ),
         ),
         local_md_params=LocalMDParams(
-            args.local_md_steps, k=args.local_md_k, min_radius=args.local_md_radius, max_radius=args.local_md_radius
+            args.local_md_steps,
+            k=args.local_md_k,
+            min_radius=args.local_md_radius,
+            max_radius=args.local_md_radius,
+            iterations=args.local_md_iterations,
         )
         if args.local_md_steps > 0
         else None,

--- a/tests/test_free_energy.py
+++ b/tests/test_free_energy.py
@@ -378,6 +378,31 @@ def test_sample_max_buffer_frames_with_local_md(
     assert len(traj.frames) == n_frames
 
 
+def test_sample_multiple_iterations_local_md(solvent_hif2a_ligand_pair_single_topology_lam0_state):
+    """Verify that running local md with multiple iterations results no frozen atoms in the local region."""
+    steps_per_frame = 800
+    n_eq_steps = 0
+
+    md_params = MDParams(
+        1, n_eq_steps, steps_per_frame, 2026, local_md_params=LocalMDParams(local_steps=steps_per_frame, iterations=1)
+    )
+    x0 = solvent_hif2a_ligand_pair_single_topology_lam0_state.x0
+    lig_idxs = solvent_hif2a_ligand_pair_single_topology_lam0_state.ligand_idxs
+    traj = sample(solvent_hif2a_ligand_pair_single_topology_lam0_state, md_params, md_params.n_frames)
+    assert isinstance(traj.frames, StoredArrays)
+    assert len(traj.frames) == 1
+    # There should be a single position (3 coordinates)
+    assert np.sum(traj.frames[-1][lig_idxs] == x0[lig_idxs]) == 3
+
+    md_params = replace(md_params, local_md_params=replace(md_params.local_md_params, iterations=10))
+
+    traj = sample(solvent_hif2a_ligand_pair_single_topology_lam0_state, md_params, md_params.n_frames)
+    assert isinstance(traj.frames, StoredArrays)
+    assert len(traj.frames) == 1
+    # None of the ligand particles should be frozen
+    assert np.sum(traj.frames[-1][lig_idxs] == x0[lig_idxs]) == 0
+
+
 @pytest.mark.nocuda
 @given(integers(min_value=1))
 @seed(2023)

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -170,6 +170,7 @@ class LocalMDParams:
     min_radius: float = 1.0  # nm
     max_radius: float = 3.0  # nm
     freeze_reference: bool = True
+    iterations: int = 1
 
     def __post_init__(self):
         assert 0.1 <= self.min_radius <= self.max_radius
@@ -905,13 +906,17 @@ def sample_with_context_iter(
                 )
                 steps = md_params.steps_per_frame
             local_steps = md_params.local_md_params.local_steps
-            x_t, box_t = ctxt.multiple_steps_local(
-                local_steps,
-                ligand_idxs.astype(np.int32),
-                k=md_params.local_md_params.k,
-                radius=rng.uniform(md_params.local_md_params.min_radius, md_params.local_md_params.max_radius),
-                seed=rng.integers(np.iinfo(np.int32).max),
-            )
+            for local_batch in batches(
+                md_params.local_md_params.local_steps,
+                md_params.local_md_params.local_steps // md_params.local_md_params.iterations,
+            ):
+                x_t, box_t = ctxt.multiple_steps_local(
+                    local_batch,
+                    ligand_idxs.astype(np.int32),
+                    k=md_params.local_md_params.k,
+                    radius=rng.uniform(md_params.local_md_params.min_radius, md_params.local_md_params.max_radius),
+                    seed=rng.integers(np.iinfo(np.int32).max),
+                )
             global_steps = steps - local_steps
             if global_steps > 0:
                 x_t, box_t = ctxt.multiple_steps(n_steps=global_steps)

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -176,6 +176,7 @@ class LocalMDParams:
         assert 0.1 <= self.min_radius <= self.max_radius
         assert self.local_steps > 0
         assert 1.0 <= self.k <= 1.0e6
+        assert self.local_steps // self.iterations >= 1
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Provides the option to run multiple rounds of local MD which will result in different atoms being the center of the region. This has not been rigorously tested, but intuitively seems useful. 