### PR TITLE
Fixes a bug when computing dG using Networkx with str node labels

### DIFF
--- a/tests/test_mle.py
+++ b/tests/test_mle.py
@@ -326,10 +326,14 @@ def test_infer_node_vals_and_errs_networkx_no_experimental_labels(seed, nx_graph
     assert g_res.nodes[center_node][node_val_prop] == 0.0
 
 
+@pytest.mark.parametrize("str_labels", [False, True])
 @pytest.mark.parametrize("seed", [2026, 814, 618])
-def test_infer_node_vals_and_errs_networkx_star_map_no_experimental_labels(seed):
+def test_infer_node_vals_and_errs_networkx_star_map_no_experimental_labels(seed, str_labels):
     rng = np.random.default_rng(seed)
+
     node_ids = np.arange(64, dtype=np.int32)
+    if str_labels:
+        node_ids = [str(x) for x in node_ids]
     rng.shuffle(node_ids)
 
     center_node = node_ids[0]

--- a/tmd/fe/mle.py
+++ b/tmd/fe/mle.py
@@ -321,7 +321,7 @@ def infer_node_vals_and_errs_networkx(
             ref_node_stddevs.append(d.get(ref_node_stddev_prop, 0.0))
     if len(ref_node_idxs) == 0:
         warnings.warn("no reference node values: picking first center node as reference")
-        center_node = sorted(nx.center(sg.to_undirected(as_view=True)))[0]
+        center_node = sorted(nx.center(sg_relabeled.to_undirected(as_view=True)))[0]
         ref_node_idxs.append(center_node)
         ref_node_vals.append(0.0)
         ref_node_stddevs.append(0.0)


### PR DESCRIPTION
* Was using the subgraph instead of the relabeled subgraph which resulted in the wrong node label being returned.
* Adds a test that both integer and str labels work, does correctly fail without fix.

Bug introduced in #130 