### PR TITLE
Exclude macrocycle rings for rest region expansion by default

### DIFF
--- a/tests/data/3RKZ_macrocycles.sdf
+++ b/tests/data/3RKZ_macrocycles.sdf
@@ -1,0 +1,1160 @@
+lignad_63
+     RDKit          3D
+
+ 66 69  0  0  1  0  0  0  0  0999 V2000
+   12.1437   -1.4835   -0.7447 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.6337   -1.4701   -0.9168 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3435   -2.1855   -1.8419 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.8614   -3.1493   -2.8871 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.3953   -2.4785   -4.1985 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.4535   -3.4183   -5.4198 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8229   -3.5735   -6.0053 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3207   -3.3513   -8.3771 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.1764   -2.5697   -7.0542 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4795   -1.7990   -6.7168 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.5016   -2.6412   -6.0863 N   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6222   -2.7603   -4.6921 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7459   -2.1010   -3.8086 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7453   -2.3995   -2.4374 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7094   -3.2750   -1.9042 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.6524   -3.8692   -2.7672 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.5972   -3.6275   -4.1566 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.5732   -4.3313   -5.0523 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4121   -5.1039   -4.3615 N   0  0  0  0  0  0  0  0  0  0  0  0
+   19.6163   -4.2267   -6.2746 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6935   -1.8851   -1.6542 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8119   -0.9855   -0.6062 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5574   -0.7291   -0.1301 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3669    0.2001    1.0067 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2558    0.5487    1.3964 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6420    0.6891    1.7092 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8492    0.8373    0.7504 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.5680    1.9954   -0.1604 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0876    1.2028    1.5138 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.1038   -0.4142   -0.1138 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6977   -2.1414   -1.4906 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7542   -0.4734   -0.8718 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8965   -1.8453    0.2533 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.6387   -3.8864   -3.0878 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0362   -3.7316   -2.4735 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.3679   -2.1426   -4.0465 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.9464   -1.5637   -4.4049 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0567   -4.3844   -5.1035 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.7628   -3.0724   -6.1912 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.3721   -3.4535   -8.6531 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8189   -2.8583   -9.2114 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.0438   -1.5399   -7.2228 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8999   -1.3828   -7.6347 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.2625   -0.9177   -6.1141 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3506   -2.8055   -6.6220 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0200   -1.3846   -4.1459 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7117   -3.5040   -0.8473 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.3980   -4.5415   -2.3658 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4120   -5.2190   -3.3581 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.1502   -5.6685   -4.7572 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4297    1.6392    2.1995 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8788   -0.0261    2.4964 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4021    2.1262   -0.8499 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4412    2.9013    0.4323 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6566    1.8004   -0.7255 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9244    1.3022    0.8225 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3088    0.4227    2.2423 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9294    2.1489    2.0313 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6217   -1.1673    0.4814 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7632   -0.1653   -0.9463 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5249   -3.4663   -5.2811 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.9036   -4.4991   -6.4013 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8928   -4.3454   -8.2469 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3201   -0.8176   -7.9908 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.1279   -2.0516   -7.5185 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.8806   -1.0208   -6.2783 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 31  1  0
+  1 32  1  0
+  1 33  1  0
+  2 23  1  0
+  2  3  2  0
+  3 21  1  0
+  3  4  1  0
+  4  5  1  0
+  4 34  1  0
+  4 35  1  0
+  5  6  1  0
+  5 36  1  0
+  5 37  1  0
+  6 38  1  0
+  6 39  1  0
+  6  7  1  0
+  7  9  1  0
+  7 61  1  0
+  7 62  1  0
+  8  9  1  0
+  8 40  1  0
+  8 41  1  0
+  8 63  1  0
+  9 10  1  0
+  9 42  1  0
+ 10 11  1  0
+ 10 43  1  0
+ 10 44  1  0
+ 11 12  1  0
+ 11 45  1  0
+ 12 17  2  0
+ 12 13  1  0
+ 13 14  2  0
+ 13 46  1  0
+ 14 15  1  0
+ 14 21  1  0
+ 15 16  2  0
+ 15 47  1  0
+ 16 17  1  0
+ 16 48  1  0
+ 17 18  1  0
+ 18 19  1  0
+ 18 20  2  0
+ 19 49  1  0
+ 19 50  1  0
+ 21 22  1  0
+ 22 30  1  0
+ 22 23  2  0
+ 23 24  1  0
+ 24 25  2  0
+ 24 26  1  0
+ 26 27  1  0
+ 26 51  1  0
+ 26 52  1  0
+ 27 28  1  0
+ 27 29  1  0
+ 27 30  1  0
+ 28 53  1  0
+ 28 54  1  0
+ 28 55  1  0
+ 29 56  1  0
+ 29 57  1  0
+ 29 58  1  0
+ 30 59  1  0
+ 30 60  1  0
+ 42 64  1  0
+ 42 65  1  0
+ 42 66  1  0
+M  CHG  1   7   1
+M  END
+>  <r_exp_dg>  (1) 
+-9.32
+
+>  <experimental dG reference units>  (1) 
+kcal/mol
+
+>  <experimental dG reference field>  (1) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (1) 
+-38.99488
+
+>  <kcal/mol experimental dG>  (1) 
+-9.32
+
+>  <AmberAM1BCCCache>  (1) 
+gASVQQUAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCOdDlkIeaOK/lIaUUpRoA2gJQwjivzUVw13Yv5SGlFKUaANoCUMIrtJsZ45GAMCUhpRSlGgDaAlDCN5gSGri7pY/lIaUUpRoA2gJQwgwq2Nw+xD0v5SGlFKUaANoCUMIWaFLXLzD8z+UhpRSlGgDaAlDCNIc/NAmSyLAlIaUUpRoA2gJQwj1a4IqW6H4v5SGlFKUaANoCUMIK1KxO68B+z+UhpRSlGgDaAlDCBMKfdKfzQFAlIaUUpRoA2gJQwjmZ/CKVlchwJSGlFKUaANoCUMIlW57r+/gAUCUhpRSlGgDaAlDCKGHwUahTwXAlIaUUpRoA2gJQwgPqsizMjLpP5SGlFKUaANoCUMIbTR8v+ft/r+UhpRSlGgDaAlDCB95bLQ6XuS/lIaUUpRoA2gJQwituBaGGFABwJSGlFKUaANoCUMIsVyjINPzH0CUhpRSlGgDaAlDCGnN1VCOsR7AlIaUUpRoA2gJQwgPwxJr2hUewJSGlFKUaANoCUMIl3TW3NKNuj+UhpRSlGgDaAlDCI2pxE7ZhMS/lIaUUpRoA2gJQwgYQHDOOx8GwJSGlFKUaANoCUMI5quG2iLLHECUhpRSlGgDaAlDCF1APXpvFhnAlIaUUpRoA2gJQwh2MufsJYoAwJSGlFKUaANoCUMI3yDaSYuq3L+UhpRSlGgDaAlDCI0Y1aQjv/G/lIaUUpRoA2gJQwiNGNWkI7/xv5SGlFKUaANoCUMIRHup7Uzv0r+UhpRSlGgDaAlDCI0V2HSo4+U/lIaUUpRoA2gJQwiNFdh0qOPlP5SGlFKUaANoCUMIjRXYdKjj5T+UhpRSlGgDaAlDCP2F1cuzl+g/lIaUUpRoA2gJQwj9hdXLs5foP5SGlFKUaANoCUMIyA/xP7NO7T+UhpRSlGgDaAlDCMgP8T+zTu0/lIaUUpRoA2gJQwh/Hd7upeXyP5SGlFKUaANoCUMIfx3e7qXl8j+UhpRSlGgDaAlDCA4Lbej6fu0/lIaUUpRoA2gJQwgOC23o+n7tP5SGlFKUaANoCUMI9WuCKluh+L+UhpRSlGgDaAlDCM53ScWKKOk/lIaUUpRoA2gJQwjOd0nFiijpP5SGlFKUaANoCUMII04WbzdNFUCUhpRSlGgDaAlDCAVBzrERpvk/lIaUUpRoA2gJQwhZweF2oL3+P5SGlFKUaANoCUMIofAJ4tPa/D+UhpRSlGgDaAlDCHtgynSOsQ5AlIaUUpRoA2gJQwh7YMp0jrEOQJSGlFKUaANoCUMIre5U26ig7j+UhpRSlGgDaAlDCK3uVNuooO4/lIaUUpRoA2gJQwiYTH4n8qvgP5SGlFKUaANoCUMImEx+J/Kr4D+UhpRSlGgDaAlDCJhMfifyq+A/lIaUUpRoA2gJQwiYTH4n8qvgP5SGlFKUaANoCUMImEx+J/Kr4D+UhpRSlGgDaAlDCJhMfifyq+A/lIaUUpRoA2gJQwj9hdXLs5foP5SGlFKUaANoCUMI/YXVy7OX6D+UhpRSlGgDaAlDCADXLROx8hRAlIaUUpRoA2gJQwgA1y0TsfIUQJSGlFKUaANoCUMIDgtt6Pp+7T+UhpRSlGgDaAlDCA4Lbej6fu0/lIaUUpRoA2gJQwgOC23o+n7tP5SGlFKUaANoCUMIDgtt6Pp+7T+UhpRSlGUu
+
+$$$$
+ligand_69
+     RDKit          3D
+
+ 80 84  0  0  1  0  0  0  0  0999 V2000
+   15.4780   -4.4160   -7.2700 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3440   -3.1150   -6.4840 C   0  0  2  0  0  0  0  0  0  0  0  0
+   13.9730   -2.4470   -6.7210 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0400   -2.7320   -5.6120 N   0  0  0  0  0  0  0  0  0  0  0  0
+   13.3200   -2.0850   -4.3170 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.7240   -3.0010   -3.1530 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.2710   -2.1580   -2.0290 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5860   -1.4270   -1.0820 C   0  0  0  0  0  0  0  0  0  0  0  0
+   12.0930   -1.3050   -0.9330 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5300   -0.7960   -0.2490 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7870   -1.1560   -0.6970 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.0760   -0.6870   -0.0890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8450    0.6940    0.5590 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.6130    1.7530   -0.5420 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0980    1.0970    1.3400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6250    0.6950    1.5040 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3560    0.1090    0.8890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2500    0.5680    1.1700 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6320   -1.9850   -1.7900 N   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7280   -2.5330   -2.5090 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7110   -3.3090   -1.9100 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7240   -3.8490   -2.7110 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7610   -3.6100   -4.0990 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.8790   -4.1680   -4.9400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.5620   -5.1990   -4.4130 N   0  0  0  0  0  0  0  0  0  0  0  0
+   20.2000   -3.6860   -6.0390 O   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7650   -2.8280   -4.6920 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7270   -2.5430   -6.0390 N   0  0  0  0  0  0  0  0  0  0  0  0
+   16.5200   -2.1260   -6.7240 C   0  0  1  0  0  0  0  0  0  0  0  0
+   16.8660   -1.8310   -8.1890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7660   -2.2660   -3.8660 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.9580   -3.5520   -5.7550 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.1990   -3.7930   -4.8060 O   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8211   -4.0986   -7.1452 C   0  0  2  0  0  0  0  0  0  0  0  0
+   10.8251   -3.2985   -7.9922 C   0  0  0  0  0  0  0  0  0  0  0  0
+    9.4485   -3.9546   -7.7916 C   0  0  0  0  0  0  0  0  0  0  0  0
+    9.6589   -5.1414   -6.8439 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.1514   -5.4753   -7.0034 N   0  0  0  0  0  0  0  0  0  0  0  0
+   14.6950   -5.1234   -6.9964 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4367   -4.8943   -7.0661 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4129   -4.2497   -8.3451 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3514   -3.4601   -5.4593 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.0760   -1.3634   -6.7909 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5548   -2.7497   -7.6827 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.0458   -1.2919   -4.4685 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.4232   -1.5401   -4.0165 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.8645   -3.5711   -2.7999 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.4543   -3.7463   -3.4618 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7813   -0.2739   -1.1006 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7875   -1.5948    0.0725 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.5633   -1.9396   -1.6429 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4050   -1.4115    0.6570 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.8635   -0.6268   -0.8416 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7445    1.5405   -1.1665 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4704    1.8187   -1.2129 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4623    2.7452   -0.1150 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9855    2.0821    1.7950 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9773    1.1338    0.6954 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3119    0.3909    2.1434 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8455    0.1027    2.3915 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4088    1.7054    1.8507 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6781   -3.5070   -0.8485 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.4898   -4.4330   -2.2254 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.2787   -5.6023   -3.5374 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.3264   -5.5751   -4.9501 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.5327   -2.8472   -6.5858 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.2482   -1.1603   -6.2961 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6223   -1.0487   -8.2637 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9881   -1.4873   -8.7363 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.2525   -2.7124   -8.7014 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0408   -1.5843   -4.2607 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.8110   -4.2190   -7.5919 H   0  0  0  0  0  0  0  0  0  0  0  0
+   10.8187   -2.2498   -7.6869 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.1196   -3.3121   -9.0440 H   0  0  0  0  0  0  0  0  0  0  0  0
+    8.7275   -3.2521   -7.3676 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.0284   -4.2914   -8.7419 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.5172   -4.8668   -5.7952 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.0609   -6.0260   -7.0758 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.3045   -6.0317   -7.8335 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.5223   -6.0237   -6.2385 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 39  1  0
+  1 40  1  0
+  1 41  1  0
+  2 29  1  0
+  2  3  1  0
+  2 42  1  1
+  3  4  1  0
+  3 43  1  0
+  3 44  1  0
+  4  5  1  0
+  4 32  1  0
+  5  6  1  0
+  5 45  1  0
+  5 46  1  0
+  6  7  1  0
+  6 47  1  0
+  6 48  1  0
+  7 19  1  0
+  7  8  2  0
+  8  9  1  0
+  8 10  1  0
+  9 49  1  0
+  9 50  1  0
+  9 51  1  0
+ 10 17  1  0
+ 10 11  2  0
+ 11 12  1  0
+ 11 19  1  0
+ 12 13  1  0
+ 12 52  1  0
+ 12 53  1  0
+ 13 14  1  0
+ 13 15  1  0
+ 13 16  1  0
+ 14 54  1  0
+ 14 55  1  0
+ 14 56  1  0
+ 15 57  1  0
+ 15 58  1  0
+ 15 59  1  0
+ 16 17  1  0
+ 16 60  1  0
+ 16 61  1  0
+ 17 18  2  0
+ 19 20  1  0
+ 20 31  2  0
+ 20 21  1  0
+ 21 22  2  0
+ 21 62  1  0
+ 22 23  1  0
+ 22 63  1  0
+ 23 24  1  0
+ 23 27  2  0
+ 24 25  1  0
+ 24 26  2  0
+ 25 64  1  0
+ 25 65  1  0
+ 27 28  1  0
+ 27 31  1  0
+ 28 29  1  0
+ 28 66  1  0
+ 29 30  1  0
+ 29 67  1  1
+ 30 68  1  0
+ 30 69  1  0
+ 30 70  1  0
+ 31 71  1  0
+ 32 33  2  0
+ 32 34  1  0
+ 34 38  1  0
+ 34 35  1  0
+ 34 72  1  6
+ 35 36  1  0
+ 35 73  1  0
+ 35 74  1  0
+ 36 37  1  0
+ 36 75  1  0
+ 36 76  1  0
+ 37 38  1  0
+ 37 77  1  0
+ 37 78  1  0
+ 38 79  1  0
+ 38 80  1  0
+M  CHG  1  38   1
+M  END
+>  <r_exp_dg>  (2) 
+-13.14
+
+>  <AmberAM1BCCCache>  (2) 
+gASVSwYAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCFEkUt4IgvG/lIaUUpRoA2gJQwgW1SWLdpXwv5SGlFKUaANoCUMIHLAQ/eqT7D+UhpRSlGgDaAlDCHkN31gjBxTAlIaUUpRoA2gJQwjobdgz1jfvP5SGlFKUaANoCUMIHzS5R+Gx1r+UhpRSlGgDaAlDCMwwQ0NzOPu/lIaUUpRoA2gJQwgQP3iolg/jv5SGlFKUaANoCUMIRIGwcatr4L+UhpRSlGgDaAlDCBGzHg3NwQbAlIaUUpRoA2gJQwisn1SVK8LGv5SGlFKUaANoCUMI+8ExiXsJ0b+UhpRSlGgDaAlDCGMlKhylaN2/lIaUUpRoA2gJQwguoL6RR6zxv5SGlFKUaANoCUMILqC+kUes8b+UhpRSlGgDaAlDCPu14128gwDAlIaUUpRoA2gJQwgRqL77duMcQJSGlFKUaANoCUMIWvM+oRqqGcCUhpRSlGgDaAlDCHB1pvFM1LY/lIaUUpRoA2gJQwiJLDCS6GrUP5SGlFKUaANoCUMINnSlu7id/L+UhpRSlGgDaAlDCPeoIWe8Ie2/lIaUUpRoA2gJQwhhSp/917gAwJSGlFKUaANoCUMII2EC26m3H0CUhpRSlGgDaAlDCBQIDgbF9h7AlIaUUpRoA2gJQwiSThHYEa8dwJSGlFKUaANoCUMIRYbzOEXI/D+UhpRSlGgDaAlDCC95wZZDriDAlIaUUpRoA2gJQwh/ETRStGkCQJSGlFKUaANoCUMIM8Jextdr9b+UhpRSlGgDaAlDCGFOhf/1H/6/lIaUUpRoA2gJQwi7HaBiZFIeQJSGlFKUaANoCUMIKtys00MkHcCUhpRSlGgDaAlDCKXXy1psyuA/lIaUUpRoA2gJQwib6MpA8Njxv5SGlFKUaANoCUMIa82TSYzu8r+UhpRSlGgDaAlDCDRsCyVKp/U/lIaUUpRoA2gJQwiTYnuHwhciwJSGlFKUaANoCUMIdJElHcE33z+UhpRSlGgDaAlDCHSRJR3BN98/lIaUUpRoA2gJQwh0kSUdwTffP5SGlFKUaANoCUMIiUF1GZLc6j+UhpRSlGgDaAlDCOZDN0VuxOo/lIaUUpRoA2gJQwjmQzdFbsTqP5SGlFKUaANoCUMIKBiyGwWD7D+UhpRSlGgDaAlDCCgYshsFg+w/lIaUUpRoA2gJQwikfGdfEoHoP5SGlFKUaANoCUMIpHxnXxKB6D+UhpRSlGgDaAlDCJNC2PbOoeM/lIaUUpRoA2gJQwiTQtj2zqHjP5SGlFKUaANoCUMIk0LY9s6h4z+UhpRSlGgDaAlDCEh6pTM2meg/lIaUUpRoA2gJQwhIeqUzNpnoP5SGlFKUaANoCUMI89jE3iR54D+UhpRSlGgDaAlDCPPYxN4keeA/lIaUUpRoA2gJQwjz2MTeJHngP5SGlFKUaANoCUMI89jE3iR54D+UhpRSlGgDaAlDCPPYxN4keeA/lIaUUpRoA2gJQwjz2MTeJHngP5SGlFKUaANoCUMIyfuZDrOk7T+UhpRSlGgDaAlDCMn7mQ6zpO0/lIaUUpRoA2gJQwh/1R+M17T9P5SGlFKUaANoCUMIJPpeMqw+/D+UhpRSlGgDaAlDCFkkjAyIbA5AlIaUUpRoA2gJQwhZJIwMiGwOQJSGlFKUaANoCUMIO4RfwB0WE0CUhpRSlGgDaAlDCMa1SOHUR98/lIaUUpRoA2gJQwgq/RjOsOPkP5SGlFKUaANoCUMIKv0YzrDj5D+UhpRSlGgDaAlDCCr9GM6w4+Q/lIaUUpRoA2gJQwjbyjbHeCH+P5SGlFKUaANoCUMIQK2rcbMk9z+UhpRSlGgDaAlDCOof7bvpkfI/lIaUUpRoA2gJQwjqH+276ZHyP5SGlFKUaANoCUMIRyKv58V58j+UhpRSlGgDaAlDCEcir+fFefI/lIaUUpRoA2gJQwjn60D5/aT0P5SGlFKUaANoCUMI5+tA+f2k9D+UhpRSlGgDaAlDCM22TSezLBZAlIaUUpRoA2gJQwjNtk0nsywWQJSGlFKUZS4=
+
+>  <experimental dG reference units>  (2) 
+kcal/mol
+
+>  <experimental dG reference field>  (2) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (2) 
+-54.97776
+
+>  <kcal/mol experimental dG>  (2) 
+-13.14
+
+$$$$
+ligand_62
+     RDKit          3D
+
+ 57 60  0  0  1  0  0  0  0  0999 V2000
+   12.0930   -1.3050   -0.9330 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5860   -1.4270   -1.0820 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.2710   -2.1580   -2.0290 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.7177   -3.1130   -3.0713 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.6934   -2.6353   -4.5494 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.6798   -3.3790   -5.3818 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.2266   -2.6854   -6.5729 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.6774   -3.1581   -6.8634 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7270   -2.5430   -6.0390 N   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7650   -2.8280   -4.6920 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7660   -2.2660   -3.8660 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7280   -2.5330   -2.5090 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7110   -3.3090   -1.9100 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7240   -3.8490   -2.7110 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7610   -3.6100   -4.0990 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.8790   -4.1680   -4.9400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.5620   -5.1990   -4.4130 N   0  0  0  0  0  0  0  0  0  0  0  0
+   20.2000   -3.6860   -6.0390 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6320   -1.9850   -1.7900 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7870   -1.1560   -0.6970 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5300   -0.7960   -0.2490 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3560    0.1090    0.8890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2500    0.5680    1.1700 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6250    0.6950    1.5040 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8450    0.6940    0.5590 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0980    1.0970    1.3400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.6130    1.7530   -0.5420 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.0760   -0.6870   -0.0890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.5485   -1.7597   -1.7580 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8024   -0.2545   -0.8920 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7685   -1.7772   -0.0050 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.2412   -4.0660   -2.9831 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.6956   -3.3667   -2.7895 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.7031   -2.8008   -4.9769 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.8544   -1.5563   -4.5861 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4993   -3.4926   -4.7968 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5816   -2.9072   -7.4248 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.2156   -1.6002   -6.4542 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7588   -4.2458   -6.8157 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.9179   -2.8974   -7.8964 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.6618   -2.6577   -6.4515 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0844   -1.5311   -4.2626 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6865   -3.5019   -0.8461 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.4939   -4.4281   -2.2232 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.3259   -5.5854   -3.5154 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.3451   -5.5558   -4.9407 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4093    1.7057    1.8510 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8459    0.1047    2.3929 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9783    1.1367    0.6969 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3130    0.3916    2.1438 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9846    2.0815    1.7967 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7422    1.5455   -1.1643 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4706    1.8204   -1.2125 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4659    2.7451   -0.1124 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4046   -1.4090    0.6599 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.8664   -0.6261   -0.8384 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3381   -4.2966   -5.6276 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 29  1  0
+  1 30  1  0
+  1 31  1  0
+  2 21  1  0
+  2  3  2  0
+  3 19  1  0
+  3  4  1  0
+  4  5  1  0
+  4 32  1  0
+  4 33  1  0
+  5  6  1  0
+  5 34  1  0
+  5 35  1  0
+  6  7  1  0
+  6 36  1  0
+  6 57  1  0
+  7  8  1  0
+  7 37  1  0
+  7 38  1  0
+  8  9  1  0
+  8 39  1  0
+  8 40  1  0
+  9 10  1  0
+  9 41  1  0
+ 10 15  2  0
+ 10 11  1  0
+ 11 12  2  0
+ 11 42  1  0
+ 12 13  1  0
+ 12 19  1  0
+ 13 14  2  0
+ 13 43  1  0
+ 14 15  1  0
+ 14 44  1  0
+ 15 16  1  0
+ 16 17  1  0
+ 16 18  2  0
+ 17 45  1  0
+ 17 46  1  0
+ 19 20  1  0
+ 20 28  1  0
+ 20 21  2  0
+ 21 22  1  0
+ 22 23  2  0
+ 22 24  1  0
+ 24 25  1  0
+ 24 47  1  0
+ 24 48  1  0
+ 25 26  1  0
+ 25 27  1  0
+ 25 28  1  0
+ 26 49  1  0
+ 26 50  1  0
+ 26 51  1  0
+ 27 52  1  0
+ 27 53  1  0
+ 27 54  1  0
+ 28 55  1  0
+ 28 56  1  0
+M  CHG  1   6   1
+M  END
+>  <r_exp_dg>  (3) 
+-6.67
+
+>  <AmberAM1BCCCache>  (3) 
+gASVlgQAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCDwamAcA+ea/lIaUUpRoA2gJQwgu7XBW6lOzv5SGlFKUaANoCUMIhg99viKuA8CUhpRSlGgDaAlDCJ8eveWUd8u/lIaUUpRoA2gJQwhwfZpfp77zP5SGlFKUaANoCUMIc8UlvYohIsCUhpRSlGgDaAlDCESjuhtqPPI/lIaUUpRoA2gJQwjByQFiSun6P5SGlFKUaANoCUMIfKB3nsiKIMCUhpRSlGgDaAlDCKEgd12EZ/U/lIaUUpRoA2gJQwiDYNbl+H0CwJSGlFKUaANoCUMIDLlPJ0gj1D+UhpRSlGgDaAlDCOWC0c93QP2/lIaUUpRoA2gJQwiMPF4bO7Dpv5SGlFKUaANoCUMIuVG1hzcKAcCUhpRSlGgDaAlDCFoeYKbshR9AlIaUUpRoA2gJQwhkI62ADi4ewJSGlFKUaANoCUMIlQ/i6+nyHcCUhpRSlGgDaAlDCJVgC9Y8TKY/lIaUUpRoA2gJQwgwdbxFZ2Wsv5SGlFKUaANoCUMIatSKeKIJBsCUhpRSlGgDaAlDCEhlHMe5sRxAlIaUUpRoA2gJQwj7k1J+E6sYwJSGlFKUaANoCUMIDcJ9P9SkAMCUhpRSlGgDaAlDCJqdjt79f92/lIaUUpRoA2gJQwheNUAepAzyv5SGlFKUaANoCUMIXjVAHqQM8r+UhpRSlGgDaAlDCBXlTSTehdS/lIaUUpRoA2gJQwhc56BDOf7oP5SGlFKUaANoCUMIXOegQzn+6D+UhpRSlGgDaAlDCFznoEM5/ug/lIaUUpRoA2gJQwjgKFVdxP3wP5SGlFKUaANoCUMI4ChVXcT98D+UhpRSlGgDaAlDCJXf1hAb6vM/lIaUUpRoA2gJQwiV39YQG+rzP5SGlFKUaANoCUMINII3+R5qFUCUhpRSlGgDaAlDCJPFgC+l8/Q/lIaUUpRoA2gJQwiTxYAvpfP0P5SGlFKUaANoCUMIax9NrlNe8T+UhpRSlGgDaAlDCGsfTa5TXvE/lIaUUpRoA2gJQwjOKSnWxtUTQJSGlFKUaANoCUMIEzeEB6xNAECUhpRSlGgDaAlDCBGBGG052v8/lIaUUpRoA2gJQwhvnTB6i7j+P5SGlFKUaANoCUMIhsHGBckzD0CUhpRSlGgDaAlDCIbBxgXJMw9AlIaUUpRoA2gJQwg4j14s5YfvP5SGlFKUaANoCUMIOI9eLOWH7z+UhpRSlGgDaAlDCHw6UlgOg+E/lIaUUpRoA2gJQwh8OlJYDoPhP5SGlFKUaANoCUMIfDpSWA6D4T+UhpRSlGgDaAlDCHw6UlgOg+E/lIaUUpRoA2gJQwh8OlJYDoPhP5SGlFKUaANoCUMIfDpSWA6D4T+UhpRSlGgDaAlDCP0v58tgHuk/lIaUUpRoA2gJQwj9L+fLYB7pP5SGlFKUaANoCUMINII3+R5qFUCUhpRSlGUu
+
+>  <experimental dG reference units>  (3) 
+kcal/mol
+
+>  <experimental dG reference field>  (3) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (3) 
+-27.90728
+
+>  <kcal/mol experimental dG>  (3) 
+-6.67
+
+$$$$
+lignad_65
+     RDKit          3D
+
+ 66 69  0  0  1  0  0  0  0  0999 V2000
+   12.1437   -1.4835   -0.7447 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.6337   -1.4701   -0.9168 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3435   -2.1855   -1.8419 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.8614   -3.1493   -2.8871 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.3953   -2.4785   -4.1985 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.4535   -3.4183   -5.4198 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8229   -3.5735   -6.0053 N   0  0  2  0  0  0  0  0  0  0  0  0
+   15.1764   -2.5697   -7.0542 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4795   -1.7990   -6.7168 C   0  0  1  0  0  0  0  0  0  0  0  0
+   17.5016   -2.6412   -6.0863 N   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6222   -2.7603   -4.6921 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7459   -2.1010   -3.8086 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7453   -2.3995   -2.4374 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7094   -3.2750   -1.9042 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.6524   -3.8692   -2.7672 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.5972   -3.6275   -4.1566 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.5732   -4.3313   -5.0523 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4121   -5.1039   -4.3615 N   0  0  0  0  0  0  0  0  0  0  0  0
+   19.6163   -4.2267   -6.2746 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6935   -1.8851   -1.6542 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8119   -0.9855   -0.6062 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5574   -0.7291   -0.1301 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3669    0.2001    1.0067 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2558    0.5487    1.3964 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6420    0.6891    1.7092 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8492    0.8373    0.7504 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.5680    1.9954   -0.1604 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0876    1.2028    1.5138 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.1038   -0.4142   -0.1138 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6977   -2.1414   -1.4906 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7542   -0.4734   -0.8718 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8965   -1.8453    0.2533 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.6387   -3.8864   -3.0878 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0362   -3.7316   -2.4735 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.3679   -2.1426   -4.0465 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.9464   -1.5637   -4.4049 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0567   -4.3844   -5.1035 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.7628   -3.0724   -6.1912 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3733   -1.8395   -7.1737 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.0724   -1.2121   -8.0113 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.2625   -0.9177   -6.1141 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3506   -2.8055   -6.6220 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0200   -1.3846   -4.1459 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7117   -3.5040   -0.8473 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.3980   -4.5415   -2.3658 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4120   -5.2190   -3.3581 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.1502   -5.6685   -4.7572 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4297    1.6392    2.1995 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8788   -0.0261    2.4964 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4021    2.1262   -0.8499 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4412    2.9013    0.4323 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6566    1.8004   -0.7255 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9244    1.3022    0.8225 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3088    0.4227    2.2423 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9294    2.1489    2.0313 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6217   -1.1673    0.4814 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7632   -0.1653   -0.9463 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5249   -3.4663   -5.2811 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.9444   -4.9665   -6.6013 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3161   -3.0909   -8.0013 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9886   -0.6695   -7.7785 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.2961   -2.0200   -8.7080 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.3525   -0.5308   -8.4649 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9380   -5.0928   -7.0314 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.7898   -5.7111   -5.8204 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.1928   -5.0960   -7.3800 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 30  1  0
+  1 31  1  0
+  1 32  1  0
+  2 22  1  0
+  2  3  2  0
+  3 20  1  0
+  3  4  1  0
+  4  5  1  0
+  4 33  1  0
+  4 34  1  0
+  5  6  1  0
+  5 35  1  0
+  5 36  1  0
+  6 37  1  0
+  6 38  1  0
+  6  7  1  0
+  7  8  1  0
+  7 58  1  1
+  7 59  1  0
+  8  9  1  0
+  8 39  1  0
+  8 60  1  0
+  9 10  1  0
+  9 40  1  0
+  9 41  1  1
+ 10 11  1  0
+ 10 42  1  0
+ 11 16  2  0
+ 11 12  1  0
+ 12 13  2  0
+ 12 43  1  0
+ 13 14  1  0
+ 13 20  1  0
+ 14 15  2  0
+ 14 44  1  0
+ 15 16  1  0
+ 15 45  1  0
+ 16 17  1  0
+ 17 18  1  0
+ 17 19  2  0
+ 18 46  1  0
+ 18 47  1  0
+ 20 21  1  0
+ 21 29  1  0
+ 21 22  2  0
+ 22 23  1  0
+ 23 24  2  0
+ 23 25  1  0
+ 25 26  1  0
+ 25 48  1  0
+ 25 49  1  0
+ 26 27  1  0
+ 26 28  1  0
+ 26 29  1  0
+ 27 50  1  0
+ 27 51  1  0
+ 27 52  1  0
+ 28 53  1  0
+ 28 54  1  0
+ 28 55  1  0
+ 29 56  1  0
+ 29 57  1  0
+ 40 61  1  0
+ 40 62  1  0
+ 40 63  1  0
+ 59 64  1  0
+ 59 65  1  0
+ 59 66  1  0
+M  CHG  1   7   1
+M  END
+>  <r_exp_dg>  (4) 
+-9.28
+
+>  <AmberAM1BCCCache>  (4) 
+gASVQQUAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCOaAMFjoR+G/lIaUUpRoA2gJQwgOFEqElJ/Xv5SGlFKUaANoCUMII/PORDUa/r+UhpRSlGgDaAlDCNaBPCLNVMu/lIaUUpRoA2gJQwgoB+XsPA3xv5SGlFKUaANoCUMIToyGAEjz8z+UhpRSlGgDaAlDCD6ODTw/2B/AlIaUUpRoA2gJQwg137VczvrvP5SGlFKUaANoCUMIxhJ1LpMmAkCUhpRSlGgDaAlDCNqciGlPliDAlIaUUpRoA2gJQwin1ZZ/djH5P5SGlFKUaANoCUMId0lBG1y+/r+UhpRSlGgDaAlDCI4RP0I6A94/lIaUUpRoA2gJQwgelYGT4bn7v5SGlFKUaANoCUMInNxNEOXq67+UhpRSlGgDaAlDCNZajWnsRgDAlIaUUpRoA2gJQwhXHRd3XMMfQJSGlFKUaANoCUMIZhdLv2N1HsCUhpRSlGgDaAlDCNz++9KGah7AlIaUUpRoA2gJQwjUQN3xxLyav5SGlFKUaANoCUMIuGlcKxn2s7+UhpRSlGgDaAlDCMu+iCEpgAbAlIaUUpRoA2gJQwgAaVfv4b4cQJSGlFKUaANoCUMIQ4NsZbAiGcCUhpRSlGgDaAlDCJ26B++DigDAlIaUUpRoA2gJQwg3T878mW7dv5SGlFKUaANoCUMIfyZUfQPY8b+UhpRSlGgDaAlDCH8mVH0D2PG/lIaUUpRoA2gJQwiFvK3+PPLSv5SGlFKUaANoCUMIYf5dG6GB5T+UhpRSlGgDaAlDCGH+XRuhgeU/lIaUUpRoA2gJQwhh/l0boYHlP5SGlFKUaANoCUMIf+5HrR0e4z+UhpRSlGgDaAlDCH/uR60dHuM/lIaUUpRoA2gJQwiQQwvZsbnwP5SGlFKUaANoCUMIkEML2bG58D+UhpRSlGgDaAlDCBcGV2dVLfM/lIaUUpRoA2gJQwgXBldnVS3zP5SGlFKUaANoCUMI/uS6Akt/9D+UhpRSlGgDaAlDCDv6FMjJ0f2/lIaUUpRoA2gJQwg93F7ZWQ7uP5SGlFKUaANoCUMIhi1k/u7iE0CUhpRSlGgDaAlDCGjNuH82m/0/lIaUUpRoA2gJQwhPrBwbLO3+P5SGlFKUaANoCUMI3dbALqc6/T+UhpRSlGgDaAlDCJjTJRt44Q5AlIaUUpRoA2gJQwiY0yUbeOEOQJSGlFKUaANoCUMIU8lOe3jP7j+UhpRSlGgDaAlDCFPJTnt4z+4/lIaUUpRoA2gJQwic3jE/mrrgP5SGlFKUaANoCUMInN4xP5q64D+UhpRSlGgDaAlDCJzeMT+auuA/lIaUUpRoA2gJQwic3jE/mrrgP5SGlFKUaANoCUMInN4xP5q64D+UhpRSlGgDaAlDCJzeMT+auuA/lIaUUpRoA2gJQwguV8e8EifpP5SGlFKUaANoCUMILlfHvBIn6T+UhpRSlGgDaAlDCIMTDh157BRAlIaUUpRoA2gJQwjNm1PkiJXuP5SGlFKUaANoCUMI/uS6Akt/9D+UhpRSlGgDaAlDCI0OgTTrBuk/lIaUUpRoA2gJQwiNDoE06wbpP5SGlFKUaANoCUMIjQ6BNOsG6T+UhpRSlGgDaAlDCFLYK/TQffM/lIaUUpRoA2gJQwhS2Cv00H3zP5SGlFKUaANoCUMIUtgr9NB98z+UhpRSlGUu
+
+>  <experimental dG reference units>  (4) 
+kcal/mol
+
+>  <experimental dG reference field>  (4) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (4) 
+-38.82752
+
+>  <kcal/mol experimental dG>  (4) 
+-9.28
+
+$$$$
+lignad_68
+     RDKit          3D
+
+ 67 71  0  0  1  0  0  0  0  0999 V2000
+   12.1437   -1.4835   -0.7447 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.6337   -1.4701   -0.9168 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3435   -2.1855   -1.8419 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.8614   -3.1493   -2.8871 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.3953   -2.4785   -4.1985 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.4535   -3.4183   -5.4198 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8229   -3.5735   -6.0053 N   0  0  1  0  0  0  0  0  0  0  0  0
+   15.0369   -4.9106   -6.6083 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.7474   -4.7347   -8.0937 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3207   -3.3513   -8.3771 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.1764   -2.5697   -7.0542 C   0  0  2  0  0  0  0  0  0  0  0  0
+   16.4795   -1.7990   -6.7168 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.5016   -2.6412   -6.0863 N   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6222   -2.7603   -4.6921 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7459   -2.1010   -3.8086 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7453   -2.3995   -2.4374 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7094   -3.2750   -1.9042 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.6524   -3.8692   -2.7672 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.5972   -3.6275   -4.1566 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.5732   -4.3313   -5.0523 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4121   -5.1039   -4.3615 N   0  0  0  0  0  0  0  0  0  0  0  0
+   19.6163   -4.2267   -6.2746 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6935   -1.8851   -1.6542 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8119   -0.9855   -0.6062 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5574   -0.7291   -0.1301 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3669    0.2001    1.0067 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2558    0.5487    1.3964 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6420    0.6891    1.7092 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8492    0.8373    0.7504 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.5680    1.9954   -0.1604 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0876    1.2028    1.5138 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.1038   -0.4142   -0.1138 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6977   -2.1414   -1.4906 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7542   -0.4734   -0.8718 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8965   -1.8453    0.2533 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.6387   -3.8864   -3.0878 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0362   -3.7316   -2.4735 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.3679   -2.1426   -4.0465 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.9464   -1.5637   -4.4049 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0567   -4.3844   -5.1035 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.7628   -3.0724   -6.1912 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0876   -5.1770   -6.4752 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.4517   -5.7122   -6.1548 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.1987   -5.5146   -8.7096 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.6714   -4.7454   -8.2765 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.3721   -3.4535   -8.6531 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8189   -2.8583   -9.2114 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3733   -1.8395   -7.1737 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8999   -1.3828   -7.6347 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.2625   -0.9177   -6.1141 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3506   -2.8055   -6.6220 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0200   -1.3846   -4.1459 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7117   -3.5040   -0.8473 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.3980   -4.5415   -2.3658 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.4120   -5.2190   -3.3581 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.1502   -5.6685   -4.7572 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4297    1.6392    2.1995 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8788   -0.0261    2.4964 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4021    2.1262   -0.8499 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4412    2.9013    0.4323 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6566    1.8004   -0.7255 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9244    1.3022    0.8225 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3088    0.4227    2.2423 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9294    2.1489    2.0313 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6217   -1.1673    0.4814 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7632   -0.1653   -0.9463 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5249   -3.4663   -5.2811 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 33  1  0
+  1 34  1  0
+  1 35  1  0
+  2 25  1  0
+  2  3  2  0
+  3 23  1  0
+  3  4  1  0
+  4  5  1  0
+  4 36  1  0
+  4 37  1  0
+  5  6  1  0
+  5 38  1  0
+  5 39  1  0
+  6 40  1  0
+  6 41  1  0
+  6  7  1  0
+  7 11  1  0
+  7  8  1  0
+  7 67  1  1
+  8  9  1  0
+  8 42  1  0
+  8 43  1  0
+  9 10  1  0
+  9 44  1  0
+  9 45  1  0
+ 10 11  1  0
+ 10 46  1  0
+ 10 47  1  0
+ 11 12  1  0
+ 11 48  1  6
+ 12 13  1  0
+ 12 49  1  0
+ 12 50  1  0
+ 13 14  1  0
+ 13 51  1  0
+ 14 19  2  0
+ 14 15  1  0
+ 15 16  2  0
+ 15 52  1  0
+ 16 17  1  0
+ 16 23  1  0
+ 17 18  2  0
+ 17 53  1  0
+ 18 19  1  0
+ 18 54  1  0
+ 19 20  1  0
+ 20 21  1  0
+ 20 22  2  0
+ 21 55  1  0
+ 21 56  1  0
+ 23 24  1  0
+ 24 32  1  0
+ 24 25  2  0
+ 25 26  1  0
+ 26 27  2  0
+ 26 28  1  0
+ 28 29  1  0
+ 28 57  1  0
+ 28 58  1  0
+ 29 30  1  0
+ 29 31  1  0
+ 29 32  1  0
+ 30 59  1  0
+ 30 60  1  0
+ 30 61  1  0
+ 31 62  1  0
+ 31 63  1  0
+ 31 64  1  0
+ 32 65  1  0
+ 32 66  1  0
+M  CHG  1   7   1
+M  END
+>  <r_exp_dg>  (5) 
+-8.45
+
+>  <AmberAM1BCCCache>  (5) 
+gASVVAUAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCLdKJjaOB+K/lIaUUpRoA2gJQwiZukWewV3Yv5SGlFKUaANoCUMIBdKOOI5GAMCUhpRSlGgDaAlDCAbVTkumTVO/lIaUUpRoA2gJQwhooJ9jinH0v5SGlFKUaANoCUMITIbvrGrl9D+UhpRSlGgDaAlDCGqecZlqLiDAlIaUUpRoA2gJQwiSgWtVshX1P5SGlFKUaANoCUMIPca/H03v8r+UhpRSlGgDaAlDCGzUSyZ2XvK/lIaUUpRoA2gJQwgz3ZKJl1jrP5SGlFKUaANoCUMIAgbXqef9AUCUhpRSlGgDaAlDCNTufgLrDiHAlIaUUpRoA2gJQwjhbJeyE/kBQJSGlFKUaANoCUMIg33baDCwBcCUhpRSlGgDaAlDCCq2SB6k0eg/lIaUUpRoA2gJQwhhLjwKLx7/v5SGlFKUaANoCUMI2pIMBow847+UhpRSlGgDaAlDCNOprFDv4AHAlIaUUpRoA2gJQwi9rDd7BAwgQJSGlFKUaANoCUMIz9HqkEaBHsCUhpRSlGgDaAlDCEa5m6Rpdh7AlIaUUpRoA2gJQwgGCLAj6O6mP5SGlFKUaANoCUMIo+ok2VuAwb+UhpRSlGgDaAlDCLU6DkiDTwbAlIaUUpRoA2gJQwg6rPXxIsscQJSGlFKUaANoCUMI2j7tTIEiGcCUhpRSlGgDaAlDCM0xCb4ligDAlIaUUpRoA2gJQwiWG+rSiarcv5SGlFKUaANoCUMI3RRXG0fX8b+UhpRSlGgDaAlDCN0UVxtH1/G/lIaUUpRoA2gJQwjliMnULC7Sv5SGlFKUaANoCUMIMRhQMKnj5T+UhpRSlGgDaAlDCDEYUDCp4+U/lIaUUpRoA2gJQwgxGFAwqePlP5SGlFKUaANoCUMId65tQ3cV5z+UhpRSlGgDaAlDCHeubUN3Fec/lIaUUpRoA2gJQwjH+tRFGkDuP5SGlFKUaANoCUMIx/rURRpA7j+UhpRSlGgDaAlDCHUc2CDK/fI/lIaUUpRoA2gJQwh1HNggyv3yP5SGlFKUaANoCUMIohAORn128z+UhpRSlGgDaAlDCKIQDkZ9dvM/lIaUUpRoA2gJQwimRLoIaWPxP5SGlFKUaANoCUMIpkS6CGlj8T+UhpRSlGgDaAlDCLwxqqqHJPI/lIaUUpRoA2gJQwi8MaqqhyTyP5SGlFKUaANoCUMI472HSmPD9j+UhpRSlGgDaAlDCLZBkWbna+s/lIaUUpRoA2gJQwi2QZFm52vrP5SGlFKUaANoCUMISU2kcElZFUCUhpRSlGgDaAlDCOI4gmChBvo/lIaUUpRoA2gJQwjwvRl96O3+P5SGlFKUaANoCUMIfui9kGM7/T+UhpRSlGgDaAlDCMhe5neyyQ5AlIaUUpRoA2gJQwjIXuZ3sskOQJSGlFKUaANoCUMIDfZQ7mFw7j+UhpRSlGgDaAlDCA32UO5hcO4/lIaUUpRoA2gJQwiYnMDC0pvgP5SGlFKUaANoCUMImJzAwtKb4D+UhpRSlGgDaAlDCJicwMLSm+A/lIaUUpRoA2gJQwiYnMDC0pvgP5SGlFKUaANoCUMImJzAwtKb4D+UhpRSlGgDaAlDCJicwMLSm+A/lIaUUpRoA2gJQwhdjdHebGfoP5SGlFKUaANoCUMIXY3R3mxn6D+UhpRSlGgDaAlDCBxZbkuW4BRAlIaUUpRlLg==
+
+>  <experimental dG reference units>  (5) 
+kcal/mol
+
+>  <experimental dG reference field>  (5) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (5) 
+-35.3548
+
+>  <kcal/mol experimental dG>  (5) 
+-8.45
+
+$$$$
+ligand_64
+     RDKit          3D
+
+ 69 72  0  0  1  0  0  0  0  0999 V2000
+   12.0930   -1.3050   -0.9330 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5860   -1.4270   -1.0820 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.2710   -2.1580   -2.0290 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.7702   -3.0826   -3.1164 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0054   -2.4627   -4.3160 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.6318   -1.3031   -5.1450 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.7255   -1.6254   -6.1168 N   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5998   -2.8070   -6.9906 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6073   -3.8984   -6.5755 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4125   -4.3088   -5.1459 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.2682   -5.1279   -7.3650 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.0985   -3.5841   -6.8657 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7270   -2.5430   -6.0390 N   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7650   -2.8280   -4.6920 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7660   -2.2660   -3.8660 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7280   -2.5330   -2.5090 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7110   -3.3090   -1.9100 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7240   -3.8490   -2.7110 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7610   -3.6100   -4.0990 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.8790   -4.1680   -4.9400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.5620   -5.1990   -4.4130 N   0  0  0  0  0  0  0  0  0  0  0  0
+   20.2000   -3.6860   -6.0390 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6320   -1.9850   -1.7900 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7870   -1.1560   -0.6970 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5300   -0.7960   -0.2490 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3560    0.1090    0.8890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2500    0.5680    1.1700 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6250    0.6950    1.5040 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8450    0.6940    0.5590 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0980    1.0970    1.3400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.6130    1.7530   -0.5420 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.0760   -0.6870   -0.0890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.5646   -2.0235   -1.5576 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7652   -0.3007   -1.2022 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.7998   -1.4892    0.1013 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5735   -3.7166   -3.4842 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0949   -3.7947   -2.6393 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.6726   -3.2682   -4.9694 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.0792   -2.0627   -3.9006 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.8284   -0.8502   -5.7284 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.9747   -0.5158   -4.4709 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8557   -0.8178   -6.7108 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5799   -3.1918   -6.9986 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.8103   -2.5017   -8.0168 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.1389   -5.0791   -4.8868 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.4042   -4.7014   -5.0148 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5530   -3.4441   -4.4973 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9582   -5.9299   -7.1029 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3516   -4.9104   -8.4298 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.2482   -5.4368   -7.1361 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6745   -4.5052   -6.7550 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.2181   -3.3038   -7.9140 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7030   -2.4822   -6.3562 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0775   -1.5299   -4.2084 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6825   -3.5063   -0.8473 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.4908   -4.4321   -2.2237 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.3075   -5.5951   -3.5243 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.3401   -5.5650   -4.9409 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4093    1.7053    1.8522 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8458    0.1035    2.3923 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9849    2.0812    1.7971 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9785    1.1362    0.6973 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.3125    0.3912    2.1437 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4710    1.8201   -1.2119 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4661    2.7447   -0.1116 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7420    1.5454   -1.1636 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4034   -1.4096    0.6600 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.8670   -0.6277   -0.8378 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6158   -1.7558   -5.6439 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 33  1  0
+  1 34  1  0
+  1 35  1  0
+  2 25  1  0
+  2  3  2  0
+  3 23  1  0
+  3  4  1  0
+  4  5  1  0
+  4 36  1  0
+  4 37  1  0
+  5  6  1  0
+  5 38  1  0
+  5 39  1  0
+  6  7  1  0
+  6 40  1  0
+  6 41  1  0
+  7  8  1  0
+  7 42  1  0
+  7 69  1  0
+  8  9  1  0
+  8 43  1  0
+  8 44  1  0
+  9 10  1  0
+  9 11  1  0
+  9 12  1  0
+ 10 45  1  0
+ 10 46  1  0
+ 10 47  1  0
+ 11 48  1  0
+ 11 49  1  0
+ 11 50  1  0
+ 12 13  1  0
+ 12 51  1  0
+ 12 52  1  0
+ 13 14  1  0
+ 13 53  1  0
+ 14 19  2  0
+ 14 15  1  0
+ 15 16  2  0
+ 15 54  1  0
+ 16 17  1  0
+ 16 23  1  0
+ 17 18  2  0
+ 17 55  1  0
+ 18 19  1  0
+ 18 56  1  0
+ 19 20  1  0
+ 20 21  1  0
+ 20 22  2  0
+ 21 57  1  0
+ 21 58  1  0
+ 23 24  1  0
+ 24 32  1  0
+ 24 25  2  0
+ 25 26  1  0
+ 26 27  2  0
+ 26 28  1  0
+ 28 29  1  0
+ 28 59  1  0
+ 28 60  1  0
+ 29 30  1  0
+ 29 31  1  0
+ 29 32  1  0
+ 30 61  1  0
+ 30 62  1  0
+ 30 63  1  0
+ 31 64  1  0
+ 31 65  1  0
+ 31 66  1  0
+ 32 67  1  0
+ 32 68  1  0
+M  CHG  1   7   1
+M  END
+>  <r_exp_dg>  (6) 
+-8.89
+
+>  <AmberAM1BCCCache>  (6) 
+gASVegUAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCE8LrH7rauK/lIaUUpRoA2gJQwh+GTiFFNrhv5SGlFKUaANoCUMIWbgM2Lar/r+UhpRSlGgDaAlDCMjFGYSFfrK/lIaUUpRoA2gJQwhZmHa90rHzv5SGlFKUaANoCUMIj9BQHDcB8z+UhpRSlGgDaAlDCDF/IhL6DiLAlIaUUpRoA2gJQwhYWmyQNrj3P5SGlFKUaANoCUMIC88hvL/n6L+UhpRSlGgDaAlDCGI6uz4EfPm/lIaUUpRoA2gJQwhiOrs+BHz5v5SGlFKUaANoCUMIT4VnJQuOAkCUhpRSlGgDaAlDCK9W0bFtnCDAlIaUUpRoA2gJQwi11yjSUOP6P5SGlFKUaANoCUMIh5z373en+b+UhpRSlGgDaAlDCEHeJ9Gfham/lIaUUpRoA2gJQwjmuA/9yYX4v5SGlFKUaANoCUMIH2OgS7a78b+UhpRSlGgDaAlDCLY4qNv0vwDAlIaUUpRoA2gJQwhorgk+2IYfQJSGlFKUaANoCUMIbY2ee3xpHsCUhpRSlGgDaAlDCPt7lRI0Fh7AlIaUUpRoA2gJQwhB3ifRn4Wpv5SGlFKUaANoCUMIhXvbxoiUx7+UhpRSlGgDaAlDCKuco5Mx+QbAlIaUUpRoA2gJQwj58gMzycocQJSGlFKUaANoCUMIj/Q7yhBHGcCUhpRSlGgDaAlDCFCk7DvZigDAlIaUUpRoA2gJQwivrwXCJbDcv5SGlFKUaANoCUMIQPzfQorA8b+UhpRSlGgDaAlDCED830KKwPG/lIaUUpRoA2gJQwj9HOXDyDPSv5SGlFKUaANoCUMI5Lw1KIyg5T+UhpRSlGgDaAlDCOS8NSiMoOU/lIaUUpRoA2gJQwjkvDUojKDlP5SGlFKUaANoCUMIsN9b9PBC5z+UhpRSlGgDaAlDCLDfW/TwQuc/lIaUUpRoA2gJQwiMIrtHI87uP5SGlFKUaANoCUMIjCK7RyPO7j+UhpRSlGgDaAlDCOEMbRHorvQ/lIaUUpRoA2gJQwjhDG0R6K70P5SGlFKUaANoCUMITZzZSnIEFUCUhpRSlGgDaAlDCFcwy6HORPM/lIaUUpRoA2gJQwhXMMuhzkTzP5SGlFKUaANoCUMIVZKRFBFT5z+UhpRSlGgDaAlDCFWSkRQRU+c/lIaUUpRoA2gJQwhVkpEUEVPnP5SGlFKUaANoCUMIVZKRFBFT5z+UhpRSlGgDaAlDCFWSkRQRU+c/lIaUUpRoA2gJQwhVkpEUEVPnP5SGlFKUaANoCUMIPNZTRYCj5z+UhpRSlGgDaAlDCDzWU0WAo+c/lIaUUpRoA2gJQwhoyiCgty0TQJSGlFKUaANoCUMIRsG+y+fd/z+UhpRSlGgDaAlDCDDUzinJHP8/lIaUUpRoA2gJQwi+/nI9RGr9P5SGlFKUaANoCUMI5+lAziLhDkCUhpRSlGgDaAlDCOfpQM4i4Q5AlIaUUpRoA2gJQwgBLMP2k23uP5SGlFKUaANoCUMIASzD9pNt7j+UhpRSlGgDaAlDCIvSMssEmeA/lIaUUpRoA2gJQwiL0jLLBJngP5SGlFKUaANoCUMIi9IyywSZ4D+UhpRSlGgDaAlDCIvSMssEmeA/lIaUUpRoA2gJQwiL0jLLBJngP5SGlFKUaANoCUMIi9IyywSZ4D+UhpRSlGgDaAlDCK2rrzEFVuk/lIaUUpRoA2gJQwitq68xBVbpP5SGlFKUaANoCUMITZzZSnIEFUCUhpRSlGUu
+
+>  <experimental dG reference units>  (6) 
+kcal/mol
+
+>  <experimental dG reference field>  (6) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (6) 
+-37.19576000000001
+
+>  <kcal/mol experimental dG>  (6) 
+-8.89
+
+$$$$
+ligand_70
+     RDKit          3D
+
+ 76 79  0  0  1  0  0  0  0  0999 V2000
+   12.0930   -1.3050   -0.9330 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5860   -1.4270   -1.0820 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.2710   -2.1580   -2.0290 C   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6320   -1.9850   -1.7900 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7870   -1.1560   -0.6970 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.5300   -0.7960   -0.2490 C   0  0  0  0  0  0  0  0  0  0  0  0
+   14.3560    0.1090    0.8890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.2500    0.5680    1.1700 O   0  0  0  0  0  0  0  0  0  0  0  0
+   15.6250    0.6950    1.5040 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8450    0.6940    0.5590 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.0760   -0.6870   -0.0890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.6130    1.7530   -0.5420 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.0980    1.0970    1.3400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7280   -2.5330   -2.5090 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7110   -3.3090   -1.9100 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7240   -3.8490   -2.7110 C   0  0  0  0  0  0  0  0  0  0  0  0
+   18.7610   -3.6100   -4.0990 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7650   -2.8280   -4.6920 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.7660   -2.2660   -3.8660 C   0  0  0  0  0  0  0  0  0  0  0  0
+   17.7270   -2.5430   -6.0390 N   0  0  0  0  0  0  0  0  0  0  0  0
+   16.5200   -2.1260   -6.7240 C   0  0  2  0  0  0  0  0  0  0  0  0
+   15.3440   -3.1150   -6.4840 C   0  0  1  0  0  0  0  0  0  0  0  0
+   13.9730   -2.4470   -6.7210 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.0400   -2.7320   -5.6120 N   0  0  0  0  0  0  0  0  0  0  0  0
+   13.3200   -2.0850   -4.3170 C   0  0  0  0  0  0  0  0  0  0  0  0
+   13.7240   -3.0010   -3.1530 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.9580   -3.5520   -5.7550 C   0  0  0  0  0  0  0  0  0  0  0  0
+   11.1990   -3.7930   -4.8060 O   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6570   -4.2020   -7.0920 C   0  0  2  0  0  0  0  0  0  0  0  0
+   10.8760   -3.2370   -7.9620 C   0  0  0  0  0  0  0  0  0  0  0  0
+   10.7660   -5.3710   -6.7840 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4780   -4.4160   -7.2700 C   0  0  0  0  0  0  0  0  0  0  0  0
+   16.8660   -1.8310   -8.1890 C   0  0  0  0  0  0  0  0  0  0  0  0
+   19.8790   -4.1680   -4.9400 C   0  0  0  0  0  0  0  0  0  0  0  0
+   20.2000   -3.6860   -6.0390 O   0  0  0  0  0  0  0  0  0  0  0  0
+   20.5620   -5.1990   -4.4130 N   0  0  0  0  0  0  0  0  0  0  0  0
+   11.8635   -0.6551   -0.0886 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6700   -0.8801   -1.8433 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.6629   -2.2913   -0.7591 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.8720    0.1471    2.4134 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.4275    1.7136    1.8379 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.8342   -0.6006   -0.8673 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.3971   -1.3966    0.6735 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.4665    1.7661   -1.2198 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.7101    1.5057   -1.1003 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.4985    2.7353   -0.0837 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.9592    1.0960    0.6718 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.9623    2.0955    1.7555 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.2662    0.3869    2.1496 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6847   -3.4862   -0.8450 H   0  0  0  0  0  0  0  0  0  0  0  0
+   19.4952   -4.4608   -2.2668 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.0242   -1.6187   -4.3100 H   0  0  0  0  0  0  0  0  0  0  0  0
+   18.5662   -2.6211   -6.5956 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.2227   -1.1767   -6.2784 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.3780   -3.3860   -5.4288 H   0  0  0  0  0  0  0  0  0  0  0  0
+   13.5480   -2.8126   -7.6558 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.1060   -1.3693   -6.8154 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.4575   -1.4881   -4.0206 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.0864   -1.3224   -4.4556 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.8499   -3.5501   -2.8028 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.4905   -3.6991   -3.4895 H   0  0  0  0  0  0  0  0  0  0  0  0
+   12.5727   -4.5252   -7.5872 H   0  0  0  0  0  0  0  0  0  0  0  0
+   10.6605   -3.7055   -8.9223 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.9403   -2.9767   -7.4672 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.4648   -2.3340   -8.1229 H   0  0  0  0  0  0  0  0  0  0  0  0
+   10.5285   -5.8490   -7.6414 H   0  0  0  0  0  0  0  0  0  0  0  0
+   11.2477   -6.0084   -6.1661 H   0  0  0  0  0  0  0  0  0  0  0  0
+   14.6248   -5.0598   -7.0563 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5075   -4.1951   -8.3370 H   0  0  0  0  0  0  0  0  0  0  0  0
+   16.3975   -4.9238   -6.9790 H   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9671   -1.5156   -8.7187 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.6112   -1.0368   -8.2340 H   0  0  0  0  0  0  0  0  0  0  0  0
+   17.2659   -2.7307   -8.6567 H   0  0  0  0  0  0  0  0  0  0  0  0
+   21.3233   -5.6167   -4.9287 H   0  0  0  0  0  0  0  0  0  0  0  0
+   20.3138   -5.5559   -3.5013 H   0  0  0  0  0  0  0  0  0  0  0  0
+    9.9220   -5.0423   -6.3371 H   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1 37  1  0
+  1 38  1  0
+  1 39  1  0
+  2  3  2  0
+  2  6  1  0
+  3  4  1  0
+  3 26  1  0
+  4  5  1  0
+  4 14  1  0
+  5  6  2  0
+  5 11  1  0
+  6  7  1  0
+  7  8  2  0
+  7  9  1  0
+  9 10  1  0
+  9 40  1  0
+  9 41  1  0
+ 10 11  1  0
+ 10 12  1  0
+ 10 13  1  0
+ 11 42  1  0
+ 11 43  1  0
+ 12 44  1  0
+ 12 45  1  0
+ 12 46  1  0
+ 13 47  1  0
+ 13 48  1  0
+ 13 49  1  0
+ 14 15  2  0
+ 14 19  1  0
+ 15 16  1  0
+ 15 50  1  0
+ 16 17  2  0
+ 16 51  1  0
+ 17 18  1  0
+ 17 34  1  0
+ 18 19  2  0
+ 18 20  1  0
+ 19 52  1  0
+ 20 21  1  0
+ 20 53  1  0
+ 21 22  1  0
+ 21 33  1  0
+ 21 54  1  1
+ 22 23  1  0
+ 22 32  1  0
+ 22 55  1  1
+ 23 24  1  0
+ 23 56  1  0
+ 23 57  1  0
+ 24 25  1  0
+ 24 27  1  0
+ 25 26  1  0
+ 25 58  1  0
+ 25 59  1  0
+ 26 60  1  0
+ 26 61  1  0
+ 27 28  2  0
+ 27 29  1  0
+ 29 30  1  0
+ 29 31  1  0
+ 29 62  1  6
+ 30 63  1  0
+ 30 64  1  0
+ 30 65  1  0
+ 31 66  1  0
+ 31 67  1  0
+ 31 76  1  0
+ 32 68  1  0
+ 32 69  1  0
+ 32 70  1  0
+ 33 71  1  0
+ 33 72  1  0
+ 33 73  1  0
+ 34 35  2  0
+ 34 36  1  0
+ 36 74  1  0
+ 36 75  1  0
+M  CHG  1  31   1
+M  END
+>  <r_exp_dg>  (7) 
+-12.74
+
+>  <AmberAM1BCCCache>  (7) 
+gASV/wUAAAAAAABdlCiMFm51bXB5Ll9jb3JlLm11bHRpYXJyYXmUjAZzY2FsYXKUk5SMBW51bXB5lIwFZHR5cGWUk5SMAmY4lImIh5RSlChLA4wBPJROTk5K/////0r/////SwB0lGJDCPmw1ud/Et+/lIaUUpRoA2gJQwiYoyhHsqriv5SGlFKUaANoCUMIuL4mmHh+/b+UhpRSlGgDaAlDCK1XSglnWMY/lIaUUpRoA2gJQwgzqSRLy4DEv5SGlFKUaANoCUMIJWQp1nm5BsCUhpRSlGgDaAlDCPzcQSP94BxAlIaUUpRoA2gJQwhaM3UZFJsZwJSGlFKUaANoCUMIDmfuJml7AMCUhpRSlGgDaAlDCMRE/S8DQ92/lIaUUpRoA2gJQwjvafZhqJHRv5SGlFKUaANoCUMIgRhh5KG+8b+UhpRSlGgDaAlDCIEYYeShvvG/lIaUUpRoA2gJQwg+j50XXYvXP5SGlFKUaANoCUMINVoouyhr/b+UhpRSlGgDaAlDCF+O6O95ruu/lIaUUpRoA2gJQwhTYmrPsKsAwJSGlFKUaANoCUMIsk7LU6k7/z+UhpRSlGgDaAlDCOFyuAG2AgDAlIaUUpRoA2gJQwjxcdoMrvAgwJSGlFKUaANoCUMI4FyGRz2WAkCUhpRSlGgDaAlDCGKZd85DsPC/lIaUUpRoA2gJQwgKVWgNQJjsP5SGlFKUaANoCUMIuRBAjevWE8CUhpRSlGgDaAlDCAaMa1Ogcew/lIaUUpRoA2gJQwj8xOyPhwXSv5SGlFKUaANoCUMI0IoH5jgdHkCUhpRSlGgDaAlDCAzdS9wvDB3AlIaUUpRoA2gJQwhkiO1FDlbgP5SGlFKUaANoCUMIph85mrug+b+UhpRSlGgDaAlDCI1Dbdi9zyPAlIaUUpRoA2gJQwi5uOZeCnvxv5SGlFKUaANoCUMIaSFmbv+D97+UhpRSlGgDaAlDCL/7ZPVtvB9AlIaUUpRoA2gJQwgZOEIKD4AdwJSGlFKUaANoCUMIYPcQNpMPH8CUhpRSlGgDaAlDCA4y2E1vZ+M/lIaUUpRoA2gJQwgOMthNb2fjP5SGlFKUaANoCUMIDjLYTW9n4z+UhpRSlGgDaAlDCK4BTbqN4O0/lIaUUpRoA2gJQwiuAU26jeDtP5SGlFKUaANoCUMIHRi3wPbl6D+UhpRSlGgDaAlDCB0Yt8D25eg/lIaUUpRoA2gJQwjstejc/Y/gP5SGlFKUaANoCUMI7LXo3P2P4D+UhpRSlGgDaAlDCOy16Nz9j+A/lIaUUpRoA2gJQwjstejc/Y/gP5SGlFKUaANoCUMI7LXo3P2P4D+UhpRSlGgDaAlDCOy16Nz9j+A/lIaUUpRoA2gJQwhCeW9nJIn9P5SGlFKUaANoCUMIlwOOADca/D+UhpRSlGgDaAlDCGf1AfoNq/w/lIaUUpRoA2gJQwjnQrXCYLUTQJSGlFKUaANoCUMIzWCgtQf14z+UhpRSlGgDaAlDCH7JH8X8/ek/lIaUUpRoA2gJQwiWS2Bez/jsP5SGlFKUaANoCUMIlktgXs/47D+UhpRSlGgDaAlDCMgi6R6Yjuw/lIaUUpRoA2gJQwjIIukemI7sP5SGlFKUaANoCUMI/pjNqpjX5z+UhpRSlGgDaAlDCP6YzaqY1+c/lIaUUpRoA2gJQwgwRTFys3H3P5SGlFKUaANoCUMI0TdYEmuk8D+UhpRSlGgDaAlDCNE3WBJrpPA/lIaUUpRoA2gJQwjRN1gSa6TwP5SGlFKUaANoCUMIWy7wJ5QiFkCUhpRSlGgDaAlDCFsu8CeUIhZAlIaUUpRoA2gJQwhEr9ZTuc/eP5SGlFKUaANoCUMIRK/WU7nP3j+UhpRSlGgDaAlDCESv1lO5z94/lIaUUpRoA2gJQwhh6ZF61qLkP5SGlFKUaANoCUMIYemRetai5D+UhpRSlGgDaAlDCGHpkXrWouQ/lIaUUpRoA2gJQwhmnWwI1k4OQJSGlFKUaANoCUMIZp1sCNZODkCUhpRSlGgDaAlDCFsu8CeUIhZAlIaUUpRlLg==
+
+>  <experimental dG reference units>  (7) 
+kcal/mol
+
+>  <experimental dG reference field>  (7) 
+r_exp_dg
+
+>  <kJ/mol experimental dG>  (7) 
+-53.30416
+
+>  <kcal/mol experimental dG>  (7) 
+-12.74
+
+$$$$

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -19,6 +19,7 @@ from functools import cache
 
 import jax
 import matplotlib.pyplot as plt
+import networkx as nx
 import numpy as np
 import pytest
 from common import ligand_from_smiles
@@ -40,8 +41,9 @@ from tmd.fe.rest.interpolation import (
 from tmd.fe.rest.single_topology import REST_REGION_ATOM_FLAG, SingleTopologyREST
 from tmd.fe.single_topology import SingleTopology
 from tmd.fe.system import GuestSystem
-from tmd.fe.utils import get_romol_conf, read_sdf_mols_by_name
+from tmd.fe.utils import get_romol_conf, read_sdf, read_sdf_mols_by_name
 from tmd.ff import Forcefield
+from tmd.graph_utils import convert_to_nx
 from tmd.md import builders
 from tmd.potentials import NonbondedInteractionGroup
 from tmd.utils import path_to_internal_file
@@ -72,11 +74,52 @@ def get_single_topology(mol_a, mol_b, core) -> SingleTopology:
 
 @cache
 def get_single_topology_rest(
-    mol_a, mol_b, core, max_temperature_scale: float, temperature_scale_interpolation_fxn: InterpolationFxnName
+    mol_a,
+    mol_b,
+    core,
+    max_temperature_scale: float,
+    temperature_scale_interpolation_fxn: InterpolationFxnName,
+    **kwargs,
 ) -> SingleTopologyREST:
     return SingleTopologyREST(
-        mol_a, mol_b, np.asarray(core), forcefield, max_temperature_scale, temperature_scale_interpolation_fxn
+        mol_a, mol_b, np.asarray(core), forcefield, max_temperature_scale, temperature_scale_interpolation_fxn, **kwargs
     )
+
+
+@pytest.mark.nogpu
+def test_single_topology_rest_macrocycle():
+    mols = read_sdf("tests/data/3RKZ_macrocycles.sdf")
+    assert len(mols) >= 2
+
+    mol_a = mols[0]
+    mol_b = mols[1]
+
+    max_ring_size = 7
+    core = get_core(mol_a, mol_b)
+    st_rest = get_single_topology_rest(mol_a, mol_b, core, 2.0, "exponential", maximum_ring_size=max_ring_size)
+
+    assert all(len(cycle) < max_ring_size for cycle in st_rest._cycles_a)
+    assert all(len(cycle) < max_ring_size for cycle in st_rest._cycles_b)
+
+    alchemical_mol = st_rest.mol(0.0)
+    alchemical_nx = convert_to_nx(alchemical_mol)
+
+    # Verify that there is a macrocyclic ring larger than max_ring_size
+    largest_ring = max(nx.cycle_basis(alchemical_nx), key=lambda x: len(x))
+    assert len(largest_ring) > max_ring_size
+
+    rest_region_atoms = st_rest.rest_region_atom_idxs
+    # There may be parts of the ring included, but shouldn't be all of it
+    assert len(set(largest_ring).intersection(rest_region_atoms)) < len(largest_ring)
+
+    st_rest_include_largest_ring = get_single_topology_rest(
+        mol_a, mol_b, core, 2.0, "exponential", maximum_ring_size=None
+    )
+
+    assert len(st_rest_include_largest_ring.rest_region_atom_idxs) > len(st_rest.rest_region_atom_idxs)
+
+    # If we allow it, all atoms will be selected
+    assert len(set(largest_ring).intersection(st_rest_include_largest_ring.rest_region_atom_idxs)) == len(largest_ring)
 
 
 @pytest.mark.nogpu

--- a/tests/rest/test_single_topology_rest.py
+++ b/tests/rest/test_single_topology_rest.py
@@ -79,6 +79,7 @@ def get_single_topology_rest(
     )
 
 
+@pytest.mark.nogpu
 @pytest.mark.parametrize("lamb", [0.0, 0.4, 0.5, 1.0])
 @pytest.mark.parametrize("temperature_scale_interpolation_fxn", ["linear", "quadratic", "exponential"])
 @pytest.mark.parametrize("mol_pair", np.random.default_rng(2024).choice(hif2a_ligand_pairs, size=3))
@@ -252,6 +253,7 @@ def get_identity_transformation(mol):
     return SingleTopologyREST(mol, mol, core, forcefield, 2.0, "linear")
 
 
+@pytest.mark.nogpu
 def test_single_topology_rest_propers():
     """Example with some propers not in the REST region"""
     mol_a = hif2a_ligands["15"]
@@ -261,6 +263,7 @@ def test_single_topology_rest_propers():
     assert set(st.target_propers.items()) < set(st.candidate_propers.items())
 
 
+@pytest.mark.nogpu
 def test_single_topology_rest_propers_identity():
     # benzene: no propers are scaled
     benzene = ligand_from_smiles("c1ccccc1")
@@ -278,6 +281,7 @@ def test_single_topology_rest_propers_identity():
     assert len(set(st.candidate_propers.values())) == 9 * 6 + 6
 
 
+@pytest.mark.nogpu
 @pytest.mark.parametrize("seed", [2026])
 def test_single_topology_custom_rest_atoms(seed):
     """Test the ability to manually specify which atoms should be included in the REST region by setting
@@ -329,6 +333,7 @@ def test_single_topology_custom_rest_atoms(seed):
     assert len(st.rest_region_atom_idxs) == st.get_num_atoms()
 
 
+@pytest.mark.nogpu
 @pytest.mark.parametrize(
     "lamb", [0.0, 0.4, 0.51, 1.0]
 )  # NOTE: asymmetry at lambda = 0.5 due to discontinuity in combine_confs

--- a/tmd/fe/rest/single_topology.py
+++ b/tmd/fe/rest/single_topology.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2025, Relay Therapeutics
+# Modifications Copyright 2026, Forrest York
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tmd/fe/rest/single_topology.py
+++ b/tmd/fe/rest/single_topology.py
@@ -83,6 +83,7 @@ class SingleTopologyREST(SingleTopology):
         forcefield: Forcefield,
         max_temperature_scale: float,
         temperature_scale_interpolation: InterpolationFxnName = "exponential",
+        maximum_ring_size: int | None = 7,
     ):
         """
         Parameters
@@ -104,15 +105,27 @@ class SingleTopologyREST(SingleTopology):
 
         temperature_scale_interpolation: str
             Interpolation function to use for temperature scaling. One of "linear", "quadratic", or "exponential"
+
+        maximum_ring_size: integer | None
+            Maximum size of ring that will be considered for expansion. If none, all rings will be accepted
         """
         super().__init__(mol_a, mol_b, core, forcefield)
         self._temperature_scale_interpolation_fxn: InterpolationFxn = get_temperature_scale_interpolation_fxn(
             max_temperature_scale, temperature_scale_interpolation
         )
+        self._maximum_ring_size = maximum_ring_size
         self._nxg_a = convert_to_nx(mol_a)
         self._nxg_b = convert_to_nx(mol_b)
-        self._cycles_a = nx.cycle_basis(self._nxg_a)
-        self._cycles_b = nx.cycle_basis(self._nxg_b)
+        self._cycles_a = [
+            cycle
+            for cycle in nx.cycle_basis(self._nxg_a)
+            if self._maximum_ring_size is None or len(cycle) < self._maximum_ring_size
+        ]
+        self._cycles_b = [
+            cycle
+            for cycle in nx.cycle_basis(self._nxg_b)
+            if self._maximum_ring_size is None or len(cycle) < self._maximum_ring_size
+        ]
 
     # expand REST region to include complete ring groups
     @staticmethod


### PR DESCRIPTION
* The 3RKZ set of macrocycles perform worse with REST partially due to the REST region expanding to the entire macrocycle ring. This change limits the ring expansion logic to up to 7 atom rings. 


All of the macrocycle sets were run in https://github.com/tmd-industries/rbfe-datasets/pull/20 Ftase got worse, but everything else seems like a wash. Since not including the entire macrocyclic ring is less surprising, it seems like a more desirable result even if it may help in some cases. 

## 3RKZ Before
<img width="977" height="678" alt="image" src="https://github.com/user-attachments/assets/b4989e35-371c-467f-880e-457138a98398" />


## 3RKZ After
<img width="978" height="678" alt="image" src="https://github.com/user-attachments/assets/21b29bf9-1b71-4525-b50e-c8ae212c56df" />
