### PR TITLE
Prevent CudaPoolClients from oversubscribing GPUs

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2025, Relay Therapeutics
+# Modifications Copyright 2026, Forrest York
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +17,9 @@
 import io
 import os
 import pickle
+import time
 import unittest
+from collections import defaultdict
 from pathlib import Path
 from unittest.mock import patch
 
@@ -134,6 +137,14 @@ def environ_check():
     return os.environ["CUDA_VISIBLE_DEVICES"]
 
 
+def sleep_based_on_gpu():
+    start = time.perf_counter()
+    gpu_idx = int(os.environ["CUDA_VISIBLE_DEVICES"])
+    time.sleep(0.5 * gpu_idx)
+    end = time.perf_counter()
+    return gpu_idx, start, end
+
+
 class TestGPUCount(unittest.TestCase):
     @patch("tmd.parallel.utils.check_output")
     def test_get_gpu_count(self, mock_output):
@@ -199,8 +210,8 @@ def test_cuda_pool_submit_kwargs(pool):
 
 @pytest.mark.parametrize("klass", [client.CUDAPoolClient, client.CUDAMPSPoolClient])
 def test_cuda_pool_too_many_workers(klass):
-    # I look forward to the day that we have 814 GPUs
-    cli = klass(814)
+    # I look forward to the day that we have 32 GPUs
+    cli = klass(32)
     with pytest.raises(AssertionError):
         cli.verify()
 
@@ -218,9 +229,41 @@ def test_cuda_pool_single_worker(klass):
 def test_cuda_pool_multiple_workers_cuda_visible_devices(klass):
     with patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "5,6,7"}):
         cli = klass(3)
+
     for i in range(10):
         result = cli.submit(environ_check).result()
         assert result == str(i % 3 + 5)
+
+
+@pytest.mark.parametrize("klass", [client.CUDAPoolClient, client.CUDAMPSPoolClient])
+def test_cuda_pool_multiple_workers_cuda_visible_devices_gpus_have_fixed_tasks(klass):
+    """Verify that assigning tasks of different wall clock times to different GPUs doesn't result in
+    more tasks allocated to a single GPU."""
+    with patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "0,1"}):
+        if klass == client.CUDAPoolClient:
+            cli = klass(2)
+        else:
+            cli = klass(2, workers_per_gpu=1)
+
+    futures = [cli.submit(sleep_based_on_gpu) for _ in range(10)]
+    results_by_gpu = defaultdict(list)
+    for fut in futures:
+        gpu, start, end = fut.result()
+        results_by_gpu[gpu].append((start, end))
+
+    def verify_monotonic_timings(res):
+        # Verify that none of the times for a single GPU overlap
+        _, last_end = res[0]
+        for start, end in res[1:]:
+            assert start < end
+            assert start > last_end
+            last_end = last_end
+
+    for vals in results_by_gpu.values():
+        verify_monotonic_timings(vals)
+
+    # The final run time of GPU zero (which has no sleep) should be faster than the single GPU case
+    assert results_by_gpu[0][-1][1] < results_by_gpu[1][-1][1]
 
 
 def test_batch_list():

--- a/tmd/parallel/client.py
+++ b/tmd/parallel/client.py
@@ -207,7 +207,7 @@ class ProcessPoolClient(AbstractClient):
         self.__init__(max_workers)
 
 
-class CUDAPoolClient(ProcessPoolClient):
+class CUDAPoolClient(AbstractClient):
     """
     Specialized wrapper for CUDA-dependent processes. Each call to submit()
     will run on a different GPU modulo num workers, which should be set to
@@ -215,20 +215,29 @@ class CUDAPoolClient(ProcessPoolClient):
     """
 
     def __init__(self, max_workers: int, max_tasks_per_child: int | None = None):
-        super().__init__(max_workers, max_tasks_per_child)
+        self.max_workers = max_workers
+        self._idx = 0
+        self._total_idx = 0
+        ctxt = multiprocessing.get_context("spawn")
         self._gpu_list = get_visible_gpus(max_workers)
+        # Have an executor per gpu, else multiple jobs can be running on the same GPU
+        self.executors = [
+            futures.ProcessPoolExecutor(max_workers=1, mp_context=ctxt, max_tasks_per_child=max_tasks_per_child)
+            for _ in range(len(self._gpu_list))
+        ]
 
     @staticmethod
-    def wrapper(max_workers, idx, fn, *args, **kwargs):
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(idx)
+    def wrapper(max_workers, gpu_idx, fn, *args, **kwargs):
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_idx)
         return fn(*args, **kwargs)
 
     def submit(self, task_fn, *args, **kwargs) -> BaseFuture:
         """
         See abstract class for documentation.
         """
-        future = self.executor.submit(
-            self.wrapper, self.max_workers, self._gpu_list[self._idx], task_fn, *args, **kwargs
+        gpu_idx = self._idx % len(self._gpu_list)
+        future = self.executors[gpu_idx].submit(
+            self.wrapper, self.max_workers, self._gpu_list[gpu_idx], task_fn, *args, **kwargs
         )
         job_id = str(self._total_idx)
         self._total_idx += 1
@@ -247,7 +256,7 @@ class CUDAPoolClient(ProcessPoolClient):
         assert len(self._gpu_list) <= gpus, "More GPUs requested than the machine has, check CUDA_VISIBLE_DEVICES"
 
 
-class CUDAMPSPoolClient(ProcessPoolClient):
+class CUDAMPSPoolClient(AbstractClient):
     """Specialized wrapper for CUDA-dependent processes, when running MPS (https://docs.nvidia.com/deploy/mps/index.html). If MPS is not running,
     this will perform worse than CUDAPoolClient.
     """
@@ -276,21 +285,31 @@ class CUDAMPSPoolClient(ProcessPoolClient):
         max_tasks_per_child: int or None
             Number of tasks to run before restarting the process. If None, will never restart child processes
         """
-        super().__init__(num_gpus * workers_per_gpu, max_tasks_per_child)
         assert workers_per_gpu > 0
         assert active_thread_usage_per_worker is None or active_thread_usage_per_worker > 0.0
+        self.max_workers = num_gpus * workers_per_gpu
+        self._idx = 0
+        self._total_idx = 0
         self.workers_per_gpu = workers_per_gpu
         self.num_gpus = num_gpus
         self._gpu_list = get_visible_gpus(num_gpus)
+
         if active_thread_usage_per_worker is None:
             # Heuristic taken from https://developer.nvidia.com/blog/maximizing-openmm-molecular-dynamics-throughput-with-nvidia-multi-process-service/#more_throughput_with_cuda_mps_active_thread_percentage%C2%A0
             self._active_thread_usage_per_worker = 200.0 / self.workers_per_gpu
         else:
             self._active_thread_usage_per_worker = active_thread_usage_per_worker
+        ctxt = multiprocessing.get_context("spawn")
+        self.executors = [
+            futures.ProcessPoolExecutor(
+                max_workers=workers_per_gpu, mp_context=ctxt, max_tasks_per_child=max_tasks_per_child
+            )
+            for _ in range(len(self._gpu_list))
+        ]
 
     @staticmethod
-    def wrapper(max_workers, idx, thread_percentage, fn, *args, **kwargs):
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(idx)
+    def wrapper(max_workers, gpu_idx, thread_percentage, fn, *args, **kwargs):
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_idx)
         os.environ["CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"] = str(thread_percentage)
         return fn(*args, **kwargs)
 
@@ -298,10 +317,11 @@ class CUDAMPSPoolClient(ProcessPoolClient):
         """
         See abstract class for documentation.
         """
-        future = self.executor.submit(
+        gpu_idx = self._idx % len(self._gpu_list)
+        future = self.executors[gpu_idx].submit(
             self.wrapper,
             self.max_workers,
-            self._gpu_list[self._idx % len(self._gpu_list)],
+            self._gpu_list[gpu_idx],
             self._active_thread_usage_per_worker,
             task_fn,
             *args,


### PR DESCRIPTION
* If the run time of tasks differed in runtime more tasks could be allocated to a GPU than expected. This could lead to OOMs or degraded performance
* Seen when running benchmarks with #137 