### PR TITLE
Clean up Code

### DIFF
--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -113,6 +113,9 @@ def test_bound_potential_execute_validation(harmonic_bond):
     bound_impl = harmonic_bond.to_gpu(np.float32).bound_impl
     verify_potential_validation(bound_impl.execute)
 
+    with pytest.raises(RuntimeError, match="provided with different number of systems than expected"):
+        bound_impl.execute(np.zeros((2, 3, 3), dtype=np.float32), np.ones(3, dtype=np.float32))
+
     execute_bound_impl(bound_impl)
 
 
@@ -127,6 +130,13 @@ def test_unbound_potential_execute_validation(harmonic_bond):
     unbound_impl.execute(
         np.zeros((3, 3), dtype=np.float32), harmonic_bond.params.astype(np.float32), np.eye(3, dtype=np.float32)
     )
+
+    with pytest.raises(RuntimeError, match="provided with different number of systems than expected"):
+        unbound_impl.execute_dim(
+            np.zeros((2, 3, 3), dtype=np.float32),
+            harmonic_bond.params.astype(np.float32),
+            np.ones((2, 3, 3), dtype=np.float32),
+        )
 
 
 def test_summed_potential_raises_on_inconsistent_lengths(harmonic_bond):

--- a/tests/test_reference_langevin_integrator.py
+++ b/tests/test_reference_langevin_integrator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from itertools import product
 
 import jax
 import numpy as np
@@ -20,7 +19,7 @@ import pytest
 from jax import grad, jit
 from jax import numpy as jnp
 
-from tmd.constants import BOLTZ
+from tmd.constants import BOLTZ, DEFAULT_TEMP
 from tmd.fe import utils
 from tmd.fe.single_topology import SingleTopology
 from tmd.ff import Forcefield
@@ -29,7 +28,11 @@ from tmd.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
 @pytest.mark.nocuda
-def test_reference_langevin_integrator(threshold=1e-4):
+@pytest.mark.parametrize("temperature", [200, DEFAULT_TEMP])
+@pytest.mark.parametrize("dt", [0.1, 0.15])
+@pytest.mark.parametrize("mass", [1.0, 2.0])
+@pytest.mark.parametrize("friction", [0.1, +np.inf])
+def test_reference_langevin_integrator(temperature, dt, friction, mass, threshold=1e-4):
     """Assert approximately canonical sampling of e^{-x^4 / kBT},
     for various settings of temperature, friction, timestep, and mass"""
 
@@ -38,38 +41,27 @@ def test_reference_langevin_integrator(threshold=1e-4):
     potential_fxn = lambda x: x**4
     force_fxn = lambda x: -4 * x**3
 
-    # loop over settings
-    temperatures = [200, 300]
-    frictions = [0.1, +np.inf]
-    dts = [0.1, 0.15]
-    masses = [1.0, 2.0]
+    # generate n_production_steps * n_copies samples
+    n_copies = 2500
+    langevin = LangevinIntegrator(force_fxn, mass, temperature, dt, friction)
 
-    all_combinations = list(product(temperatures, frictions, dts, masses))
-    settings = [all_combinations[0], all_combinations[-1]]  # reduced to speed up CI
-    print(f"testing reference integrator for {len(settings)} combinations of settings:")
+    x0, v0 = 0.1 * np.ones((2, n_copies))
+    xs, vs = langevin.multiple_steps(x0, v0, n_steps=2500)
+    samples = xs[10:].flatten()
+
+    # summarize using histogram
+    y_empirical, edges = np.histogram(samples, bins=100, range=(-2, +2), density=True)
+    x_grid = (edges[1:] + edges[:-1]) / 2
+
+    # compare with e^{-U(x) / kB T} / Z
+    y = np.exp(-potential_fxn(x_grid) / (BOLTZ * temperature))
+    y_ref = y / np.trapezoid(y, x_grid)
+
+    histogram_mse = np.mean((y_ref - y_empirical) ** 2)
     print("(temperature, friction, dt, mass) -> histogram_mse")
+    print(f"{(temperature, friction, dt, mass)}".ljust(33), "->", histogram_mse)
 
-    for temperature, friction, dt, mass in settings:
-        # generate n_production_steps * n_copies samples
-        n_copies = 2500
-        langevin = LangevinIntegrator(force_fxn, mass, temperature, dt, friction)
-
-        x0, v0 = 0.1 * np.ones((2, n_copies))
-        xs, vs = langevin.multiple_steps(x0, v0, n_steps=2500)
-        samples = xs[10:].flatten()
-
-        # summarize using histogram
-        y_empirical, edges = np.histogram(samples, bins=100, range=(-2, +2), density=True)
-        x_grid = (edges[1:] + edges[:-1]) / 2
-
-        # compare with e^{-U(x) / kB T} / Z
-        y = np.exp(-potential_fxn(x_grid) / (BOLTZ * temperature))
-        y_ref = y / np.trapezoid(y, x_grid)
-
-        histogram_mse = np.mean((y_ref - y_empirical) ** 2)
-        print(f"{(temperature, friction, dt, mass)}".ljust(33), "->", histogram_mse)
-
-        assert histogram_mse < threshold
+    assert histogram_mse < threshold
 
 
 @pytest.mark.nocuda

--- a/tmd/cpp/src/kernels/k_harmonic_torsion.cuh
+++ b/tmd/cpp/src/kernels/k_harmonic_torsion.cuh
@@ -15,7 +15,7 @@
 #include "../fixed_point.hpp"
 #include "../gpu_utils.cuh"
 #include "k_fixed_point.cuh"
-#include "k_periodic_torsion.cuh" // reuse dot_product / cross_product
+#include "k_math.cuh"
 
 namespace tmd {
 

--- a/tmd/cpp/src/kernels/k_integrator.cuh
+++ b/tmd/cpp/src/kernels/k_integrator.cuh
@@ -20,21 +20,24 @@ namespace tmd {
 
 template <typename RealType, int D>
 __global__ void
-k_update_forward_baoab(const int num_systems, const int N, const RealType ca,
+k_update_forward_baoab(const int num_systems, const int N, const RealType dt,
+                       const RealType ca,
                        const unsigned int *__restrict__ idxs,   // N
                        const RealType *__restrict__ cbs,        // N
                        const RealType *__restrict__ ccs,        // N
                        curandState_t *__restrict__ rand_states, // N
                        RealType *__restrict__ x_t,              // N x 3
                        RealType *__restrict__ v_t,              // N x 3
-                       unsigned long long *__restrict__ du_dx,  // N x 3
-                       const RealType dt) {
+                       unsigned long long *__restrict__ du_dx   // N x 3
+) {
   static_assert(D == 3);
 
   const int system_idx = blockIdx.y;
   if (system_idx >= num_systems) {
     return;
   }
+
+  const RealType half_dt = static_cast<RealType>(0.5) * dt;
 
   int kernel_idx = blockIdx.x * blockDim.x + threadIdx.x;
   while (kernel_idx < N) {
@@ -66,6 +69,12 @@ k_update_forward_baoab(const int num_systems, const int N, const RealType ca,
       RealType v_mid_z =
           v_t[system_idx * N * D + atom_idx * D + 2] + atom_cbs * force_z;
 
+      // Zero out the forces after using them to avoid having to memset the
+      // forces later
+      du_dx[system_idx * N * D + atom_idx * D + 0] = 0;
+      du_dx[system_idx * N * D + atom_idx * D + 1] = 0;
+      du_dx[system_idx * N * D + atom_idx * D + 2] = 0;
+
       RealType noise_x;
       RealType noise_y;
       template_curand_normal2(noise_x, noise_y, &local_state);
@@ -79,20 +88,11 @@ k_update_forward_baoab(const int num_systems, const int N, const RealType ca,
           atom_ccs * template_curand_normal<RealType>(&local_state);
 
       x_t[system_idx * N * D + atom_idx * D + 0] +=
-          static_cast<RealType>(0.5) * dt *
-          (v_mid_x + v_t[system_idx * N * D + atom_idx * D + 0]);
+          half_dt * (v_mid_x + v_t[system_idx * N * D + atom_idx * D + 0]);
       x_t[system_idx * N * D + atom_idx * D + 1] +=
-          static_cast<RealType>(0.5) * dt *
-          (v_mid_y + v_t[system_idx * N * D + atom_idx * D + 1]);
+          half_dt * (v_mid_y + v_t[system_idx * N * D + atom_idx * D + 1]);
       x_t[system_idx * N * D + atom_idx * D + 2] +=
-          static_cast<RealType>(0.5) * dt *
-          (v_mid_z + v_t[system_idx * N * D + atom_idx * D + 2]);
-
-      // Zero out the forces after using them to avoid having to memset the
-      // forces later
-      du_dx[system_idx * N * D + atom_idx * D + 0] = 0;
-      du_dx[system_idx * N * D + atom_idx * D + 1] = 0;
-      du_dx[system_idx * N * D + atom_idx * D + 2] = 0;
+          half_dt * (v_mid_z + v_t[system_idx * N * D + atom_idx * D + 2]);
 
       // Write the random state back into memory
       rand_states[system_idx * N + atom_idx] = local_state;

--- a/tmd/cpp/src/kernels/k_math.cuh
+++ b/tmd/cpp/src/kernels/k_math.cuh
@@ -1,0 +1,37 @@
+// Copyright 2019-2025, Relay Therapeutics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "../gpu_utils.cuh"
+
+namespace tmd {
+
+template <typename RealType>
+inline __device__ RealType dot_product(const RealType a[3],
+                                       const RealType b[3]) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+template <typename RealType>
+inline __device__ void cross_product(const RealType a[3], const RealType b[3],
+                                     RealType c[3]) {
+  // these extra __dmul_rn calls are needed to preserve bitwise
+  // anticommutativity i.e. cross(a,b) is bitwise identical to -cross(b,a)
+  // except in the sign-bit
+  c[0] = rmul_rn(a[1], b[2]) - rmul_rn(a[2], b[1]);
+  c[1] = rmul_rn(a[2], b[0]) - rmul_rn(a[0], b[2]);
+  c[2] = rmul_rn(a[0], b[1]) - rmul_rn(a[1], b[0]);
+}
+
+} // namespace tmd

--- a/tmd/cpp/src/kernels/k_periodic_torsion.cuh
+++ b/tmd/cpp/src/kernels/k_periodic_torsion.cuh
@@ -14,27 +14,11 @@
 // limitations under the License.
 
 #include "../fixed_point.hpp"
-#include "../gpu_utils.cuh"
+#include "../math_utils.cuh"
 #include "k_fixed_point.cuh"
+#include "k_math.cuh"
 
 namespace tmd {
-
-template <typename RealType>
-inline __device__ RealType dot_product(const RealType a[3],
-                                       const RealType b[3]) {
-  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-}
-
-template <typename RealType>
-inline __device__ void cross_product(const RealType a[3], const RealType b[3],
-                                     RealType c[3]) {
-  // these extra __dmul_rn calls are needed to preserve bitwise
-  // anticommutativity i.e. cross(a,b) is bitwise identical to -cross(b,a)
-  // except in the sign-bit
-  c[0] = rmul_rn(a[1], b[2]) - rmul_rn(a[2], b[1]);
-  c[1] = rmul_rn(a[2], b[0]) - rmul_rn(a[0], b[2]);
-  c[2] = rmul_rn(a[0], b[1]) - rmul_rn(a[1], b[0]);
-}
 
 template <typename RealType, int D, bool COMPUTE_U, bool COMPUTE_DU_DX,
           bool COMPUTE_DU_DP>

--- a/tmd/cpp/src/langevin_integrator.cu
+++ b/tmd/cpp/src/langevin_integrator.cu
@@ -83,8 +83,8 @@ void LangevinIntegrator<RealType>::step_fwd(
 
   k_update_forward_baoab<RealType, D>
       <<<dim3(ceil_divide(N_, tpb), batch_size_), tpb, 0, stream>>>(
-          batch_size_, N_, ca_, d_idxs, d_cbs_, d_ccs_, d_rand_states_.data,
-          d_x_t, d_v_t, d_du_dx_, dt_);
+          batch_size_, N_, dt_, ca_, d_idxs, d_cbs_, d_ccs_,
+          d_rand_states_.data, d_x_t, d_v_t, d_du_dx_);
   gpuErrchk(cudaPeekAtLastError());
 }
 

--- a/tmd/cpp/src/wrap_kernels.cpp
+++ b/tmd/cpp/src/wrap_kernels.cpp
@@ -1470,6 +1470,12 @@ void declare_potential(py::module &m, const char *typestr) {
                   "Boxes must have same number of batches as coords");
             }
 
+            if (batches != pot.num_systems()) {
+              throw std::runtime_error(
+                  "Potential::execute_dim provided with different number of "
+                  "systems than expected");
+            }
+
             const long unsigned int N = coords.shape(1);
             const long unsigned int D = coords.shape(2);
 
@@ -1618,11 +1624,14 @@ void declare_bound_potential(py::module &m, const char *typestr) {
              bool compute_du_dx, bool compute_u) -> py::tuple {
             long unsigned int N;
             long unsigned int D;
+            int input_systems;
             if (coords.ndim() == 2) {
+              input_systems = 1;
               N = coords.shape()[0];
               D = coords.shape()[1];
               verify_coords_and_box(coords, box);
             } else if (coords.ndim() == 3) {
+              input_systems = coords.shape(0);
               N = coords.shape(1);
               D = coords.shape(2);
             } else {
@@ -1632,6 +1641,11 @@ void declare_bound_potential(py::module &m, const char *typestr) {
                   "BoundPotential::execute failed for unknown reason");
             }
             const int num_systems = bp.potential->num_systems();
+            if (input_systems != num_systems) {
+              throw std::runtime_error(
+                  "BoundPotential::execute provided with different number of "
+                  "systems than expected");
+            }
             // initialize with fixed garbage values for debugging convenience
             // (these should be overwritten by `execute_host`)
             std::vector<unsigned long long> du_dx;


### PR DESCRIPTION
A couple of minor changes that came up while working on constraints

* Move the dot/cross product code to its own math file to avoid imports from torsion files
* Parallelize a test using pytest.mark.parameterize
* Clean up the langevin integrator kernels
* Add some error checking in potentials to make sure different shapes are as expected. Previously could lead to garbage results. 