### PR TITLE
Deduplicate Benchmarking Code

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2025, Relay Therapeutics
+# Modifications Copyright 2026, Forrest York
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +20,7 @@ relative binding free energy edge from the HIF2A test system"""
 import hashlib
 import time
 from argparse import ArgumentParser
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Optional
 
 import matplotlib.pyplot as plt
@@ -33,9 +34,12 @@ from tmd.fe.free_energy import (
     AbsoluteFreeEnergy,
     HostConfig,
     InitialState,
+    LocalMDParams,
     MDParams,
     WaterSamplingParams,
+    get_batched_context,
     get_context,
+    sample_with_context_iter,
 )
 from tmd.fe.model_utils import apply_hmr
 from tmd.fe.rbfe import setup_initial_state
@@ -45,15 +49,13 @@ from tmd.ff import Forcefield
 from tmd.lib import LangevinIntegrator, MonteCarloBarostat, custom_ops
 from tmd.md import builders
 from tmd.md.barostat.utils import compute_box_volume, get_bond_list, get_group_indices
+from tmd.md.thermostat.utils import sample_velocities
 from tmd.potentials import (
-    BoundPotential,
-    HarmonicBond,
     Nonbonded,
     NonbondedInteractionGroup,
     Potential,
     SummedPotential,
 )
-from tmd.potentials.potential import get_bound_potential_by_type
 from tmd.testsystems.dhfr import setup_dhfr
 from tmd.testsystems.relative import get_hif2a_ligand_pair_single_topology
 from tmd.utils import path_to_internal_file
@@ -74,6 +76,15 @@ class BenchmarkConfig:
         assert self.num_batches >= 1
         assert self.steps_per_batch >= 1
         assert self.num_equil_batches >= 1
+
+    def get_md_params(self):
+        """Utility function to construct MD parameters implied by the config"""
+        return MDParams(
+            n_frames=1,
+            n_eq_steps=0,
+            steps_per_frame=self.steps_per_batch,
+            seed=2026,
+        )
 
 
 def plot_batch_times(steps_per_batch: int, dt: float, batch_times: list[float], box_volumes: list[float], label: str):
@@ -117,6 +128,34 @@ def plot_batch_times(steps_per_batch: int, dt: float, batch_times: list[float], 
 @pytest.fixture(scope="module")
 def hi2fa_test_frames():
     return generate_hif2a_frames(100, 10, seed=2022, barostat_interval=20)
+
+
+def initial_state_from_host_config(
+    host_config: HostConfig,
+    dt: float,
+    temperature: float = constants.DEFAULT_TEMP,
+    seed: int = 2026,
+    barostat_interval: int = 25,
+) -> InitialState:
+    system = host_config.host_system
+    hmr_masses = apply_hmr(host_config.masses, system.bond.potential.idxs)
+
+    group_idxs = get_group_indices(get_bond_list(system.bond.potential), len(hmr_masses))
+    baro = None
+    if barostat_interval > 0:
+        baro = MonteCarloBarostat(
+            len(hmr_masses), constants.DEFAULT_PRESSURE, temperature, group_idxs, barostat_interval, seed
+        )
+
+    x0 = host_config.conf
+    # initialize integrator
+    friction = 1.0
+    intg = LangevinIntegrator(temperature, dt, friction, hmr_masses, seed)
+    protein_idxs = np.arange(0, len(hmr_masses) - host_config.num_water_atoms, dtype=np.int32)
+    ligand_idxs = np.array([], dtype=np.int32)
+
+    v0 = sample_velocities(hmr_masses, temperature, seed)
+    return InitialState(system.get_U_fns(), intg, baro, x0, v0, host_config.box, 0.0, ligand_idxs, protein_idxs)
 
 
 def generate_hif2a_frames(n_frames: int, frame_interval: int, seed=None, barostat_interval: int = 5):
@@ -205,78 +244,55 @@ def benchmark_potential(
     )
 
 
-def benchmark(
-    config: BenchmarkConfig,
-    label: str,
-    masses: NDArray,
-    x0: NDArray,
-    v0: NDArray,
-    box: NDArray,
-    bound_potentials: list[BoundPotential],
-    dt: float = 1.5e-3,
-    barostat_interval: int = 0,
-    num_systems: int = 1,
+def benchmark_initial_state(
+    config: BenchmarkConfig, label: str, state: InitialState, md_params: MDParams, num_systems: int = 1
 ):
-    if config.local_only:
+    if config.local_only and md_params.local_md_params is None:
         return
-    if barostat_interval > 0:
-        label += f"-barostat-interval-{barostat_interval}"
-    seed = 1234
-    temperature = constants.DEFAULT_TEMP
-    pressure = constants.DEFAULT_PRESSURE
+    if num_systems == 1:
+        ctxt = get_context(state, md_params)
+    else:
+        ctxt = get_batched_context([state] * num_systems, md_params)
 
-    harmonic_bond_potential = get_bound_potential_by_type(bound_potentials, HarmonicBond)
-    bond_list = get_bond_list(harmonic_bond_potential.potential)
+    expected_movers = 0
+    if state.barostat is not None:
+        expected_movers += 1
+        label += f"-barostat-interval-{state.barostat.interval}"
+    if md_params.water_sampling_params is not None:
+        water_sampling_interval = md_params.water_sampling_params.interval
+        expected_movers += 1
+        label += f"-water-sampling-interval-{water_sampling_interval}"
+        if config.steps_per_batch < water_sampling_interval:
+            print("Warning::Not running water sampling every batch, interval is too large")
+    assert len(ctxt.get_movers()) == expected_movers
 
-    intg = LangevinIntegrator(temperature, dt, 1.0, np.array([masses] * num_systems), seed).impl()
-
-    bps = []
-
-    for potential in bound_potentials:
-        combined_bp = potential
-        for _ in range(num_systems - 1):
-            combined_bp = combined_bp.combine(potential)
-        bps.append(combined_bp.to_gpu(precision=np.float32).bound_impl)  # get the bound implementation
-
-    for bp in bps:
-        assert bp.num_systems() == num_systems
-
-    movers = []
-    if barostat_interval > 0:
-        group_idxs = get_group_indices(bond_list, len(masses))
-        baro = MonteCarloBarostat(
-            x0.shape[0],
-            pressure,
-            temperature,
-            group_idxs,
-            barostat_interval,
-            seed,
-        )
-        movers.append(baro.impl(bps))
-
-    ctxt = custom_ops.Context_f32(
-        np.array([x0] * num_systems, dtype=np.float32).squeeze(),
-        np.array([v0] * num_systems, dtype=np.float32).squeeze(),
-        np.array([box] * num_systems, dtype=np.float32).squeeze(),
-        intg,
-        bps,
-        movers=movers,
-    )
+    if md_params.local_md_params is not None:
+        assert md_params.local_md_params.min_radius == md_params.local_md_params.max_radius
 
     batch_times = []
     box_volumes = []
 
     steps_per_batch = config.steps_per_batch
     num_batches = config.num_batches
+
+    assert md_params.n_frames == 1
+    assert md_params.steps_per_frame == steps_per_batch
+    assert md_params.n_eq_steps == 0
+
+    dt = state.integrator.dt
+
+    temperature = state.integrator.temperature
+
     # run num_equil_batches before starting the time, can improve benchmark accuracy
-    ctxt.multiple_steps(steps_per_batch * config.num_equil_batches)
+    for _ in range(config.num_equil_batches):
+        next(sample_with_context_iter(ctxt, md_params, temperature, state.ligand_idxs, 1))
 
     start = time.perf_counter()
 
     for batch in range(num_batches):
         # time the current batch
         batch_start = time.perf_counter()
-        xs, boxes = ctxt.multiple_steps(steps_per_batch)
+        xs, boxes, _ = next(sample_with_context_iter(ctxt, md_params, temperature, state.ligand_idxs, 1))
         batch_end = time.perf_counter()
         if num_systems == 1:
             box_volumes.append(compute_box_volume(boxes[-1]))
@@ -299,170 +315,19 @@ def benchmark(
 
     determinism_hash = hashlib.md5(xs[-1].tobytes()).hexdigest()[:8]
 
-    print(
-        f"{label}: Systems={num_systems} N={x0.shape[0]} speed: {ns_per_day:.2f}ns/day dt: {dt * 1e3}fs (ran {steps_per_batch * num_batches} steps in {(time.perf_counter() - start):.2f}s) | determinism hash: {determinism_hash}"
-    )
+    if md_params.local_md_params is None:
+        print(
+            f"{label}: Systems={num_systems} N={state.x0.shape[0]} speed: {ns_per_day:.2f}ns/day dt: {dt * 1e3}fs (ran {steps_per_batch * num_batches} steps in {(time.perf_counter() - start):.2f}s) | determinism hash: {determinism_hash}"
+        )
+    else:
+        radius = md_params.local_md_params.min_radius
+        k = md_params.local_md_params.k
+        print(
+            f"{label}: Systems={num_systems} N={state.x0.shape[0]} Radius={radius}, K={k} speed: {ns_per_day:.2f}ns/day dt: {dt * 1e3}fs (ran {steps_per_batch * num_batches} steps in {(time.time() - start):.2f}s) | determinism hash: {determinism_hash}"
+        )
 
     if config.generate_plots and num_systems == 1:
         plot_batch_times(steps_per_batch, dt, batch_times, box_volumes, label)
-
-
-def benchmark_rbfe_water_sampling(
-    config: BenchmarkConfig,
-    label: str,
-    state: InitialState,
-    water_sampling_interval: int = 400,
-    radius: float = 1.0,
-    batch_size: int = 250,
-):
-    if config.local_only:
-        return
-    if state.barostat is not None:
-        label += f"-barostat-interval-{state.barostat.interval}"
-    label += f"-water-sampling-interval-{water_sampling_interval}"
-    seed = 1234
-
-    if config.steps_per_batch < water_sampling_interval:
-        print("Warning::Not running water sampling every batch, interval is too large")
-
-    ctxt = get_context(
-        state,
-        MDParams(
-            n_frames=1,
-            n_eq_steps=0,
-            steps_per_frame=1,
-            seed=seed,
-            water_sampling_params=WaterSamplingParams(
-                interval=water_sampling_interval, radius=radius, batch_size=batch_size
-            ),
-        ),
-    )
-    assert len(ctxt.get_movers()) == 2, "Expected barostat and water sampler"
-
-    batch_times = []
-    box_volumes = []
-
-    steps_per_batch = config.steps_per_batch
-    num_batches = config.num_batches
-
-    dt = state.integrator.dt
-
-    # run num_equil_batches before starting the time, can improve benchmark accuracy
-    ctxt.multiple_steps(steps_per_batch * config.num_equil_batches)
-
-    start = time.time()
-
-    for batch in range(num_batches):
-        # time the current batch
-        batch_start = time.time()
-        xs, boxes = ctxt.multiple_steps(steps_per_batch)
-        batch_end = time.time()
-        box_volumes.append(compute_box_volume(boxes[-1]))
-
-        delta = batch_end - batch_start
-
-        batch_times.append(delta)
-
-        steps_per_second = steps_per_batch / np.mean(batch_times)
-        steps_per_day = steps_per_second * SECONDS_PER_DAY
-
-        ps_per_day = dt * steps_per_day
-        ns_per_day = ps_per_day * 1e-3
-
-        if config.verbose:
-            print(f"steps per second: {steps_per_second:.3f}")
-            print(f"ns per day: {ns_per_day:.3f}")
-
-    if config.generate_plots:
-        plot_batch_times(steps_per_batch, dt, batch_times, box_volumes, label)
-    assert np.all(np.abs(ctxt.get_x_t()) < 1000)
-
-    print(
-        f"{label}: N={state.x0.shape[0]} speed: {ns_per_day:.2f}ns/day dt: {dt * 1e3}fs (ran {steps_per_batch * num_batches} steps in {(time.time() - start):.2f}s)"
-    )
-
-
-def benchmark_local(
-    config: BenchmarkConfig,
-    label: str,
-    masses: NDArray,
-    x0: NDArray,
-    v0: NDArray,
-    box: NDArray,
-    bound_potentials: list[BoundPotential],
-    ligand_idxs: NDArray,
-    dt: float = 1.5e-3,
-    radius: float = 1.2,
-    k: float = 10_000.0,
-):
-    seed = 1234
-    temperature = constants.DEFAULT_TEMP
-    friction = 1.0
-
-    rng = np.random.default_rng(seed)
-
-    intg = LangevinIntegrator(temperature, dt, friction, np.asarray(masses), seed).impl()
-
-    bps = []
-
-    for potential in bound_potentials:
-        bps.append(potential.to_gpu(precision=np.float32).bound_impl)  # get the bound implementation
-
-    ctxt = custom_ops.Context_f32(
-        x0.astype(np.float32),
-        v0.astype(np.float32),
-        box.astype(np.float32),
-        intg,
-        bps,
-    )
-
-    batch_times = []
-    box_volumes = []
-
-    steps_per_batch = config.steps_per_batch
-    num_batches = config.num_batches
-
-    ligand_idxs = ligand_idxs.astype(np.int32)
-
-    local_seed = rng.integers(np.iinfo(np.int32).max)
-    # run num_equil_batches before starting the time, can improve benchmark accuracy
-    ctxt.multiple_steps_local(
-        steps_per_batch * config.num_equil_batches, ligand_idxs, seed=local_seed, radius=radius, k=k
-    )
-
-    start = time.time()
-
-    for batch in range(num_batches):
-        local_seed = rng.integers(np.iinfo(np.int32).max)
-        # time the current batch
-        batch_start = time.time()
-        xs, boxes = ctxt.multiple_steps_local(steps_per_batch, ligand_idxs, seed=local_seed, radius=radius, k=k)
-        batch_end = time.time()
-        box_volumes.append(compute_box_volume(boxes[-1]))
-
-        delta = batch_end - batch_start
-
-        batch_times.append(delta)
-
-        steps_per_second = steps_per_batch / np.mean(batch_times)
-        steps_per_day = steps_per_second * SECONDS_PER_DAY
-
-        ps_per_day = dt * steps_per_day
-        ns_per_day = ps_per_day * 1e-3
-
-        if config.verbose:
-            print(f"steps per second: {steps_per_second:.3f}")
-            print(f"ns per day: {ns_per_day:.3f}")
-
-    if config.generate_plots:
-        plot_batch_times(steps_per_batch, dt, batch_times, box_volumes, label)
-    assert np.all(np.abs(ctxt.get_x_t()) < 1000)
-
-    determinism_hash = hashlib.md5(xs[-1].tobytes()).hexdigest()[:8]
-
-    print(
-        f"{label}: N={x0.shape[0]} Radius={radius}, K={k} speed: {ns_per_day:.2f}ns/day dt: {dt * 1e3}fs (ran {steps_per_batch * num_batches} steps in {(time.time() - start):.2f}s) | determinism hash: {determinism_hash}"
-    )
 
 
 def run_single_topology_benchmarks(
@@ -473,108 +338,77 @@ def run_single_topology_benchmarks(
 ):
     initial_state = setup_initial_state(st, 0.1, host_config, constants.DEFAULT_TEMP, 2022, True)
 
+    dt = 2.5e-3
     for num_systems in [1, 2, 4]:
-        barostat_interval = 0
         if host_config is not None:
-            host_fns = host_config.host_system.get_U_fns()
-            host_masses = host_config.masses
-
-            # RBFE
-            x0 = initial_state.x0[: len(host_config.conf)]
-            v0 = np.zeros_like(x0)
-
-            harmonic_bond_potential = get_bound_potential_by_type(host_fns, HarmonicBond).potential
-            bond_list = get_bond_list(harmonic_bond_potential)
-            dt = 2.5e-3
-            hmr_masses = apply_hmr(host_masses, bond_list)
-
             for barostat_interval in [0, 25]:
-                benchmark(
+                apo_state = initial_state_from_host_config(host_config, dt, barostat_interval=barostat_interval)
+                benchmark_initial_state(
                     config,
                     f"{stage}-apo",
-                    np.array(hmr_masses),
-                    x0,
-                    v0,
-                    initial_state.box0,
-                    host_fns,
-                    barostat_interval=barostat_interval,
-                    dt=dt,
+                    apo_state,
+                    config.get_md_params(),
                     num_systems=num_systems,
                 )
-            assert initial_state.barostat is not None
-            barostat_interval = initial_state.barostat.interval
 
-        benchmark(
+        benchmark_initial_state(
             config,
             f"{stage}-rbfe",
-            initial_state.integrator.masses,
-            initial_state.x0,
-            initial_state.v0,
-            initial_state.box0,
-            initial_state.potentials,
-            dt=initial_state.integrator.dt,
-            barostat_interval=barostat_interval,
+            initial_state,
+            config.get_md_params(),
             num_systems=num_systems,
         )
 
     if host_config is not None:
-        benchmark_local(
+        benchmark_initial_state(
             config,
             f"{stage}-rbfe-local",
-            initial_state.integrator.masses,
-            initial_state.x0,
-            initial_state.v0,
-            initial_state.box0,
-            initial_state.potentials,
-            initial_state.ligand_idxs,
-            dt=initial_state.integrator.dt,
+            initial_state,
+            replace(
+                config.get_md_params(),
+                local_md_params=LocalMDParams(config.steps_per_batch, min_radius=1.2, max_radius=1.2, k=10_000.0),
+            ),
         )
 
         # Only in the case where the ligand is in complex do we want to look at water sampling
         if host_config.num_water_atoms < host_config.conf.shape[0]:
-            benchmark_rbfe_water_sampling(
+            benchmark_initial_state(
                 config,
                 f"{stage}-rbfe",
                 initial_state,
-                water_sampling_interval=400,
+                replace(
+                    config.get_md_params(),
+                    water_sampling_params=WaterSamplingParams(interval=400, radius=1.0, batch_size=250),
+                ),
             )
 
 
 def benchmark_dhfr(config: BenchmarkConfig):
     host_fns, host_masses, host_conf, box = setup_dhfr()
 
-    x0 = host_conf
-    v0 = np.zeros_like(host_conf)
-
-    harmonic_bond_potential = get_bound_potential_by_type(host_fns, HarmonicBond).potential
-    bond_list = get_bond_list(harmonic_bond_potential)
     dt = 2.5e-3
-    hmr_masses = apply_hmr(host_masses, bond_list)
+    with path_to_internal_file("tmd.testsystems.data", "5dfr_solv_equil.pdb") as pdb_path:
+        host_config = builders.load_pdb_system(str(pdb_path), "amber99sbildn", "tip3p", cutoff=1.2)
 
     for barostat_interval in [0, 25]:
+        apo_state = initial_state_from_host_config(host_config, dt, barostat_interval=barostat_interval)
         for num_systems in [1, 2, 4]:
-            benchmark(
+            benchmark_initial_state(
                 config,
                 "dhfr-apo",
-                hmr_masses,
-                x0,
-                v0,
-                box,
-                host_fns,
-                barostat_interval=barostat_interval,
-                dt=dt,
+                apo_state,
+                config.get_md_params(),
                 num_systems=num_systems,
             )
-    benchmark_local(
+    apo_state = initial_state_from_host_config(host_config, dt)
+    benchmark_initial_state(
         config,
         "dhfr-local",
-        hmr_masses,
-        x0,
-        v0,
-        box,
-        host_fns,
-        np.arange(len(host_conf), dtype=np.int32),
-        dt=dt,
+        replace(apo_state, ligand_idxs=np.arange(len(host_config.conf), dtype=np.int32)),
+        replace(
+            config.get_md_params(),
+            local_md_params=LocalMDParams(config.steps_per_batch, min_radius=1.2, max_radius=1.2, k=10_000.0),
+        ),
     )
 
 
@@ -622,35 +456,25 @@ def benchmark_ahfe(config: BenchmarkConfig):
         afe, forcefield, host_config, constants.DEFAULT_TEMP, np.array([0.0]), seed
     )[0]
 
-    barostat_interval = 0
-    if initial_state.barostat is not None:
-        barostat_interval = initial_state.barostat.interval
-
     for num_systems in [1, 2, 4]:
-        benchmark(
+        benchmark_initial_state(
             config,
             "ahfe",
-            initial_state.integrator.masses,
-            initial_state.x0,
-            initial_state.v0,
-            initial_state.box0,
-            initial_state.potentials,
-            barostat_interval=barostat_interval,
-            dt=initial_state.integrator.dt,
+            initial_state,
+            config.get_md_params(),
             num_systems=num_systems,
         )
-    if host_config is not None:
-        benchmark_local(
-            config,
-            "ahfe-local",
-            initial_state.integrator.masses,
-            initial_state.x0,
-            initial_state.v0,
-            initial_state.box0,
-            initial_state.potentials,
-            initial_state.ligand_idxs,
-            dt=initial_state.integrator.dt,
-        )
+        if host_config is not None:
+            benchmark_initial_state(
+                config,
+                "ahfe-local",
+                initial_state,
+                replace(
+                    config.get_md_params(),
+                    local_md_params=LocalMDParams(config.steps_per_batch, min_radius=1.2, max_radius=1.2, k=10_000.0),
+                ),
+                num_systems=num_systems,
+            )
 
 
 def test_dhfr():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -123,6 +123,7 @@ def plot_batch_times(steps_per_batch: int, dt: float, batch_times: list[float], 
     fig.tight_layout()
     fig.savefig(f"{label}.png", dpi=150)
     plt.clf()
+    plt.close()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Reduces the duplicated code in the benchmarking script while also preparing for benchmarking different timesteps with constraints