### PR TITLE
Modifies Benchmark example to be more complete

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, replace
 import jax
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy.typing import NDArray
 
 # Enable 64 bit jax, only to remove the noise of the Pymbar warning
 jax.config.update("jax_enable_x64", True)
@@ -21,21 +20,17 @@ from tmd.fe.free_energy import (
     MDParams,
     get_batched_context,
     get_context,
+    initial_state_from_host_config,
     run_sims_hrex,
     sample_with_context_iter,
 )
-from tmd.fe.model_utils import apply_hmr
-from tmd.fe.rbfe import setup_in_env
+from tmd.fe.rbfe import setup_initial_state, setup_initial_states, setup_optimized_host
 from tmd.fe.single_topology import SingleTopology
-from tmd.fe.utils import get_romol_conf, read_sdf
+from tmd.fe.utils import read_sdf
 from tmd.ff import Forcefield
-from tmd.lib import Context, LangevinIntegrator, MonteCarloBarostat
 from tmd.md import builders
-from tmd.md.barostat.utils import get_bond_list, get_group_indices
+from tmd.md.thermostat.utils import sample_velocities
 from tmd.parallel.client import CUDAMPSPoolClient
-from tmd.potentials import HarmonicBond
-from tmd.potentials.potential import get_bound_potential_by_type
-from tmd.testsystems.dhfr import setup_dhfr
 from tmd.testsystems.relative import get_hif2a_ligand_pair_single_topology
 from tmd.utils import path_to_internal_file
 
@@ -44,110 +39,105 @@ SECONDS_PER_DAY = 24 * 60 * 60
 
 @dataclass
 class MDSystemData:
-    x0: NDArray
-    box0: NDArray
-    masses: NDArray
-    pots: list
-    intg: LangevinIntegrator
-    baro: MonteCarloBarostat
+    initial_states: list[InitialState]
     params: MDParams
-    ligand_idxs: NDArray
-    hrex: bool
     hrex_states: int
 
 
 def run_mps_steps(system_data):
     """Runs Simulations in parallel through Nvidia's MPS"""
-    if not system_data.hrex:
-        state = InitialState(
-            system_data.pots,
-            system_data.intg,
-            system_data.baro,
-            system_data.x0,
-            np.zeros_like(system_data.x0),
-            system_data.box0,
-            0.0,
-            system_data.ligand_idxs,
-            protein_idxs=np.empty(0, dtype=np.int32),
-            interacting_atoms=system_data.ligand_idxs,
-        )
+    assert len(system_data.initial_states) == 1
+    state = system_data.initial_states[0]
+    ctxt = get_context(state, system_data.params)
+    start = time.perf_counter()
+
+    if system_data.params.hrex_params is None:
         ctxt = get_context(state, system_data.params)
         start = time.perf_counter()
-        for _ in sample_with_context_iter(
-            ctxt, system_data.params, system_data.intg.temperature, system_data.ligand_idxs, 1
-        ):
+        for _ in sample_with_context_iter(ctxt, system_data.params, state.integrator.temperature, state.ligand_idxs, 1):
             pass
     else:
         states = [
-            InitialState(
-                system_data.pots,
-                system_data.intg,
-                system_data.baro,
-                system_data.x0,
-                np.zeros_like(system_data.x0),
-                system_data.box0,
-                lamb,
-                system_data.ligand_idxs,
-                protein_idxs=np.empty(0, dtype=np.int32),
-                interacting_atoms=system_data.ligand_idxs,
+            replace(
+                state,
+                v0=sample_velocities(
+                    state.integrator.masses, state.integrator.temperature, system_data.params.seed + i
+                ),
             )
-            for lamb in np.linspace(0.0, 1.0, system_data.hrex_states)
+            for i in range(system_data.hrex_states)
         ]
-        assert len(states) == system_data.hrex_states
         start = time.perf_counter()
         run_sims_hrex(states, system_data.params, print_diagnostics_interval=None, batch_simulations=False)
-
     return time.perf_counter() - start
 
 
 def run_batched_steps(system_data):
     """Runs the simulations in the batch mode, which removes the need for MPS to improve throughput"""
-    if not system_data.hrex:
-        states = [
-            InitialState(
-                system_data.pots,
-                system_data.intg,
-                system_data.baro,
-                coords,
-                np.zeros_like(coords),
-                box,
-                0.0,
-                system_data.ligand_idxs,
-                protein_idxs=np.empty(0, dtype=np.int32),
-                interacting_atoms=system_data.ligand_idxs,
-            )
-            for coords, box in zip(system_data.x0, system_data.box0)
-        ]
+    states = system_data.initial_states
+    if system_data.params.hrex_params is None:
         if len(states) > 1:
             ctxt = get_batched_context(states, system_data.params)
         else:
             ctxt = get_context(states[0], system_data.params)
         start = time.perf_counter()
         for _ in sample_with_context_iter(
-            ctxt, system_data.params, system_data.intg.temperature, system_data.ligand_idxs, 1
+            ctxt,
+            system_data.params,
+            states[0].integrator.temperature,
+            states[0].ligand_idxs,
+            system_data.params.n_frames,
         ):
             pass
     else:
-        n_systems = system_data.x0.shape[0]
-        states = [
-            InitialState(
-                system_data.pots,
-                system_data.intg,
-                system_data.baro,
-                coords,
-                np.zeros_like(coords),
-                box,
-                lamb,
-                system_data.ligand_idxs,
-                protein_idxs=np.empty(0, dtype=np.int32),
-                interacting_atoms=system_data.ligand_idxs,
-            )
-            for lamb, coords, box in zip(np.linspace(0.0, 1.0, n_systems), system_data.x0, system_data.box0)
-        ]
         start = time.perf_counter()
         run_sims_hrex(states, system_data.params, print_diagnostics_interval=None, batch_simulations=True)
-
     return time.perf_counter() - start
+
+
+def generate_equilibrium_frames(initial_states, md_params, eq_steps, dt_fs):
+    num_samples = len(initial_states)
+    if all(state.lamb == initial_states[0].lamb for state in initial_states):
+        equil_params = replace(
+            md_params,
+            n_eq_steps=eq_steps,
+            n_frames=num_samples,
+            local_md_params=None,
+            steps_per_frame=int(1000 / dt_fs),  # Aim for 1 picosecond between frames
+        )
+        ctxt = get_context(initial_states[0], equil_params)
+        xs, boxes, _ = next(
+            sample_with_context_iter(
+                ctxt,
+                equil_params,
+                initial_states[0].integrator.temperature,
+                initial_states[0].ligand_idxs,
+                equil_params.n_frames,
+            )
+        )
+    else:
+        equil_params = replace(
+            md_params,
+            n_eq_steps=eq_steps,
+            n_frames=1,
+            local_md_params=None,
+            steps_per_frame=int(1000 / dt_fs),  # Aim for 1 picosecond between frames
+        )
+        xs = np.empty((num_samples, *initial_states[0].x0.shape))
+        boxes = np.empty((num_samples, 3, 3))
+        for i, state in enumerate(initial_states):
+            ctxt = get_context(state, equil_params)
+            x, b, _ = next(
+                sample_with_context_iter(
+                    ctxt,
+                    equil_params,
+                    initial_states[0].integrator.temperature,
+                    initial_states[0].ligand_idxs,
+                    equil_params.n_frames,
+                )
+            )
+            xs[i] = x[-1]
+            boxes[i] = b[-1]
+    return xs, boxes
 
 
 def main():
@@ -177,7 +167,7 @@ def main():
     parser.add_argument(
         "--n_eq_steps",
         type=int,
-        default=50_000,
+        default=10_000,
         help="Number of global steps to run to equilibrate the system. Important to get reliable results from batch mode.",
     )
     parser.add_argument(
@@ -186,6 +176,7 @@ def main():
         default=8,
         help="Number of HREX states. Only applies to MPS, for batched the number of HREX states is the number of replicas",
     )
+    parser.add_argument("--dt_fs", default=2.5, type=float, help="The timestep in femptoseconds")
     parser.add_argument("--system", default="dhfr", choices=["dhfr", "hif2a-rbfe", "hif2a", "pfkfb3-rbfe"])
     args = parser.parse_args()
 
@@ -193,30 +184,33 @@ def main():
     if output_suffix is None:
         date = datetime.now()
         date_str = date.strftime("%Y_%b_%d_%H_%M")
-        output_suffix = f"_{date_str}"
+        output_suffix = f"_{date_str}_{args.dt_fs:.1f}fs"
 
     seed = args.seed
     temperature = constants.DEFAULT_TEMP
-    pressure = constants.DEFAULT_PRESSURE
     ff = Forcefield.load_default()
 
-    if args.system == "dhfr":
-        host_fns, host_masses, x0, box0 = setup_dhfr()
-        # Treat the entire system as the ligand indices
-        ligand_idxs = np.arange(len(x0))
-        harmonic_bond_potential = get_bound_potential_by_type(host_fns, HarmonicBond).potential
-        bond_list = get_bond_list(harmonic_bond_potential)
-        hmr_masses = apply_hmr(host_masses, bond_list)
+    assert args.dt_fs > 0.0
+    dt = args.dt_fs * 1e-3
 
-        group_idxs = get_group_indices(bond_list, len(hmr_masses))
-        baro = MonteCarloBarostat(
-            x0.shape[0],
-            pressure,
-            temperature,
-            group_idxs,
-            25,  # Run Barostat every 25 steps if not running local MD
-            seed,
-        )
+    num_samples = np.max(args.processes)
+
+    if args.system in ("dhfr", "hif2a"):
+        if args.system == "dhfr":
+            with path_to_internal_file("tmd.testsystems.data", "5dfr_solv_equil.pdb") as pdb_path:
+                host_config = builders.load_pdb_system(str(pdb_path), "amber99sbildn", "tip3p", cutoff=1.2)
+        else:
+            with path_to_internal_file("tmd.testsystems.fep_benchmark.hif2a", "5tbm_solv_equil.pdb") as protein_path:
+                host_config = builders.load_pdb_system(str(protein_path), ff.protein_ff, ff.water_ff)
+        initial_state = initial_state_from_host_config(host_config, dt=dt, temperature=temperature, seed=seed)
+        initial_state.ligand_idxs = np.arange(len(host_config.conf), dtype=np.int32)
+        if args.hrex:
+            initial_states = [
+                replace(initial_state, lamb=lamb)
+                for lamb in np.linspace(0.0, 1.0, args.hrex_states if not args.batch_mode else num_samples)
+            ]
+        else:
+            initial_states = [initial_state] * num_samples
     elif args.system.endswith("-rbfe"):
         if args.system == "hif2a-rbfe":
             mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
@@ -234,80 +228,33 @@ def main():
                 host_config = builders.build_protein_system(
                     str(protein_path), ff.protein_ff, ff.water_ff, box_margin=0.1
                 )
-
-        lamb = 0.0
-
         st = SingleTopology(mol_a, mol_b, core, ff)
+        host_config = setup_optimized_host(host_config, [mol_a, mol_b], ff)
 
-        conf_a = get_romol_conf(mol_a)
-        conf_b = get_romol_conf(mol_b)
-
-        ligand_conf = st.combine_confs(conf_a, conf_b, lamb)
-
-        x0, hmr_masses, host_fns, baro = setup_in_env(st, host_config, ligand_conf, lamb, temperature, seed)
-        box0 = host_config.box
-        ligand_idxs = np.arange(len(host_config.conf), len(x0))
-    elif args.system == "hif2a":
-        with path_to_internal_file("tmd.testsystems.fep_benchmark.hif2a", "5tbm_solv_equil.pdb") as protein_path:
-            host_config = builders.load_pdb_system(str(protein_path), ff.protein_ff, ff.water_ff)
-
-        host_fns, host_masses, x0, box0 = (
-            host_config.host_system.get_U_fns(),
-            host_config.masses,
-            host_config.conf,
-            host_config.box,
-        )
-        ligand_idxs = np.arange(len(x0))
-        harmonic_bond_potential = get_bound_potential_by_type(host_fns, HarmonicBond).potential
-        bond_list = get_bond_list(harmonic_bond_potential)
-        hmr_masses = apply_hmr(host_masses, bond_list)
-
-        group_idxs = get_group_indices(bond_list, len(hmr_masses))
-        baro = MonteCarloBarostat(
-            x0.shape[0],
-            pressure,
-            temperature,
-            group_idxs,
-            25,  # Run Barostat every 25 steps if not running local MD
-            seed,
-        )
+        if args.hrex:
+            initial_states = setup_initial_states(
+                st,
+                host_config,
+                temperature,
+                np.linspace(0.0, 1.0, args.hrex_states if not args.batch_mode else num_samples),
+                seed,
+                False,
+                dt=dt,
+            )
+        else:
+            initial_states = [setup_initial_state(st, 0.0, host_config, temperature, seed, False, dt=dt)] * num_samples
     else:
         assert 0, f"Unknown system {args.system}"
 
-    v0 = np.zeros_like(x0)
-
-    dt = 2.5e-3
-
-    intg = LangevinIntegrator(temperature, dt, 1.0, np.asarray(hmr_masses), seed)
-
-    bps = []
-
-    for potential in host_fns:
-        bps.append(potential.to_gpu(precision=np.float32).bound_impl)  # get the bound implementation
-
-    movers = []
-
-    movers.append(baro.impl(bps))
-
-    ctxt = Context(
-        x0,
-        v0,
-        box0,
-        intg.impl(),
-        bps,
-        movers=movers,
-    )
-
-    num_samples = np.max(args.processes)
-
-    ctxt.multiple_steps(args.n_eq_steps)
-    # Get a range of samples that don't have the same neighborlist to add some variation
-    # in the runtime (IE Neighborlist, etc)
-    xs, boxes = ctxt.multiple_steps(400 * num_samples, store_x_interval=num_samples)
+    # Resample the velocities to ensure they aren't all zero
+    initial_states = [
+        replace(state, v0=sample_velocities(state.integrator.masses, temperature, seed=seed + i))
+        for i, state in enumerate(initial_states)
+    ]
 
     md_params = MDParams(
         n_eq_steps=0,
-        n_frames=args.frames if not args.hrex else args.frames // args.hrex_states,
+        n_frames=args.frames,
         steps_per_frame=args.steps,
         seed=seed,
         local_md_params=LocalMDParams(
@@ -319,12 +266,13 @@ def main():
         )
         if args.local_md
         else None,
-        hrex_params=HREXParams(),
+        hrex_params=HREXParams() if args.hrex else None,
+        dt=dt,
     )
 
-    state = MDSystemData(
-        x0, box0, np.array(hmr_masses), host_fns, intg, baro, md_params, ligand_idxs, args.hrex, args.hrex_states
-    )
+    xs, boxes = generate_equilibrium_frames(initial_states, md_params, args.n_eq_steps, args.dt_fs)
+
+    system_data = MDSystemData(initial_states, md_params, args.hrex_states)
 
     skip_single_proc = args.hrex and args.batch_mode and 1 in args.processes
     ns_per_day_results = []
@@ -332,20 +280,26 @@ def main():
         if proc == 1 and skip_single_proc:
             print("Skipping single process for batch mode with HREX, must have at least 2 simulations")
             continue
+
         mps_workers = proc
         if args.batch_mode:
             mps_workers = 1
         pool = CUDAMPSPoolClient(
             1, workers_per_gpu=mps_workers, active_thread_usage_per_worker=args.active_thread_percentage
         )
-        subset_xs = xs[:proc]
-        subset_boxes = boxes[:proc]
+        pool.verify()
+
         if not args.batch_mode:
             futures = [
                 pool.submit(
-                    run_mps_steps, replace(state, x0=x, box0=box, params=replace(md_params, seed=md_params.seed + i))
+                    run_mps_steps,
+                    replace(
+                        system_data,
+                        initial_states=[replace(state, x0=xs[i], box0=boxes[i])],
+                        params=replace(md_params, seed=md_params.seed + i + proc),
+                    ),
                 )
-                for i, (x, box) in enumerate(zip(subset_xs, subset_boxes))
+                for i, state in enumerate(initial_states[:proc])
             ]
         else:
             # Combine all steps into a single state
@@ -353,7 +307,12 @@ def main():
                 pool.submit(
                     run_batched_steps,
                     replace(
-                        state, x0=xs[:proc], box0=boxes[:proc], params=replace(md_params, seed=md_params.seed + proc)
+                        system_data,
+                        initial_states=[
+                            replace(state, x0=xs[i], box0=boxes[i]) if not args.hrex else state
+                            for i, state in enumerate(initial_states[:proc])
+                        ],
+                        params=replace(md_params, seed=md_params.seed + proc),
                     ),
                 )
             ]
@@ -361,6 +320,7 @@ def main():
         frames_run = md_params.steps_per_frame * md_params.n_frames
         if args.batch_mode:
             frames_run *= proc
+            print(frames_run)
         elif args.hrex:
             frames_run *= args.hrex_states
         steps_per_second = frames_run / np.array(results)
@@ -392,7 +352,7 @@ def main():
     plt.ylabel("Factor improvement")
     plt.xlabel("Processes")
     plt.title(
-        f"{args.system}"
+        f"{args.system} {args.dt_fs:.1f}fs"
         + (f"\nLocal MD Rad {args.local_md_rad}" if args.local_md else "")
         + (f"\n{args.hrex_states} HREX Windows" if args.hrex and not args.batch_mode else "")
     )

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -320,7 +320,6 @@ def main():
         frames_run = md_params.steps_per_frame * md_params.n_frames
         if args.batch_mode:
             frames_run *= proc
-            print(frames_run)
         elif args.hrex:
             frames_run *= args.hrex_states
         steps_per_second = frames_run / np.array(results)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -39,17 +39,16 @@ from tmd.fe.free_energy import (
     WaterSamplingParams,
     get_batched_context,
     get_context,
+    initial_state_from_host_config,
     sample_with_context_iter,
 )
-from tmd.fe.model_utils import apply_hmr
 from tmd.fe.rbfe import setup_initial_state
 from tmd.fe.single_topology import SingleTopology
 from tmd.fe.topology import BaseTopology
 from tmd.ff import Forcefield
-from tmd.lib import ConstrainedLangevinIntegrator, LangevinIntegrator, MonteCarloBarostat, custom_ops
+from tmd.lib import custom_ops
 from tmd.md import builders
-from tmd.md.barostat.utils import compute_box_volume, get_bond_list, get_group_indices
-from tmd.md.thermostat.utils import sample_velocities
+from tmd.md.barostat.utils import compute_box_volume
 from tmd.potentials import (
     Nonbonded,
     NonbondedInteractionGroup,
@@ -129,39 +128,6 @@ def plot_batch_times(steps_per_batch: int, dt: float, batch_times: list[float], 
 @pytest.fixture(scope="module")
 def hi2fa_test_frames():
     return generate_hif2a_frames(100, 10, seed=2022, barostat_interval=20)
-
-
-def initial_state_from_host_config(
-    host_config: HostConfig,
-    dt: float,
-    temperature: float = constants.DEFAULT_TEMP,
-    seed: int = 2026,
-    barostat_interval: int = 25,
-) -> InitialState:
-    system = host_config.host_system
-    hmr_masses = apply_hmr(host_config.masses, system.bond.potential.idxs)
-
-    group_idxs = get_group_indices(get_bond_list(system.bond.potential), len(hmr_masses))
-    baro = None
-    if barostat_interval > 0:
-        baro = MonteCarloBarostat(
-            len(hmr_masses), constants.DEFAULT_PRESSURE, temperature, group_idxs, barostat_interval, seed
-        )
-
-    x0 = host_config.conf
-    # initialize integrator
-    friction = 1.0
-    intg: ConstrainedLangevinIntegrator | LangevinIntegrator
-    if dt > 2.5e-3:
-        assert host_config.constraints
-        intg = ConstrainedLangevinIntegrator(temperature, dt, friction, hmr_masses, seed, host_config.constraints)
-    else:
-        intg = LangevinIntegrator(temperature, dt, friction, hmr_masses, seed)
-    protein_idxs = np.arange(0, len(hmr_masses) - host_config.num_water_atoms, dtype=np.int32)
-    ligand_idxs = np.array([], dtype=np.int32)
-
-    v0 = sample_velocities(hmr_masses, temperature, seed)
-    return InitialState(system.get_U_fns(), intg, baro, x0, v0, host_config.box, 0.0, ligand_idxs, protein_idxs)
 
 
 def generate_hif2a_frames(n_frames: int, frame_interval: int, seed: int = 2022, barostat_interval: int = 5):
@@ -344,10 +310,10 @@ def run_single_topology_benchmarks(
     st: SingleTopology,
     host_config: Optional[HostConfig],
 ):
-    for dt in [2.5e-3, 4.0e-3]:
+    for dt in [4.5e-3]:
         initial_state = setup_initial_state(st, 0.1, host_config, constants.DEFAULT_TEMP, 2022, True, dt=dt)
 
-        for num_systems in [1, 2, 4]:
+        for num_systems in [1, 4, 8, 16, 32, 48]:
             if host_config is not None:
                 for barostat_interval in [0, 25]:
                     apo_state = initial_state_from_host_config(host_config, dt, barostat_interval=barostat_interval)

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -26,7 +26,7 @@ from numpy.typing import NDArray
 from rdkit import Chem
 
 from tmd._vendored.pymbar.utils import kln_to_kn
-from tmd.constants import BOLTZ, NBParamIdx
+from tmd.constants import BOLTZ, DEFAULT_PRESSURE, DEFAULT_TEMP, NBParamIdx
 from tmd.fe import model_utils, topology
 from tmd.fe.bar import (
     bar_with_pessimistic_uncertainty,
@@ -38,6 +38,7 @@ from tmd.fe.bar import (
 )
 from tmd.fe.interpolate import linear_interpolation, pad
 from tmd.fe.lambda_schedule import construct_pre_optimized_relative_lambda_schedule, interpolate_pre_optimized_protocol
+from tmd.fe.model_utils import apply_hmr
 from tmd.fe.plots import (
     plot_as_png_fxn,
     plot_dG_errs_figure,
@@ -55,6 +56,7 @@ from tmd.md.builders import HostConfig
 from tmd.md.exchange.exchange_mover import WaterSamplingDiagnostics, get_water_idxs
 from tmd.md.hrex import HREX, HREXDiagnostics, ReplicaIdx, StateIdx, get_swap_attempts_per_iter_heuristic
 from tmd.md.states import CoordsVelBox
+from tmd.md.thermostat.utils import sample_velocities
 from tmd.potentials import (
     BoundPotential,
     HarmonicBond,
@@ -2496,3 +2498,35 @@ def run_sims_hrex(
         ws_diagnostics = WaterSamplingDiagnostics(np.array(water_sampler_proposals_by_state_by_iter, dtype=np.int32))
 
     return PairBarResult(list(initial_states), pair_bar_results), samples_by_state, hrex_diagnostics, ws_diagnostics
+
+
+# TBD: Move this elsewhere, this file is way too large
+def initial_state_from_host_config(
+    host_config: HostConfig,
+    dt: float,
+    temperature: float = DEFAULT_TEMP,
+    seed: int = 2026,
+    barostat_interval: int = 25,
+) -> InitialState:
+    system = host_config.host_system
+    hmr_masses = apply_hmr(host_config.masses, system.bond.potential.idxs)
+
+    group_idxs = get_group_indices(get_bond_list(system.bond.potential), len(hmr_masses))
+    baro = None
+    if barostat_interval > 0:
+        baro = MonteCarloBarostat(len(hmr_masses), DEFAULT_PRESSURE, temperature, group_idxs, barostat_interval, seed)
+
+    x0 = host_config.conf
+    # initialize integrator
+    friction = 1.0
+    intg: ConstrainedLangevinIntegrator | LangevinIntegrator
+    if dt > 2.5e-3:
+        assert host_config.constraints
+        intg = ConstrainedLangevinIntegrator(temperature, dt, friction, hmr_masses, seed, host_config.constraints)
+    else:
+        intg = LangevinIntegrator(temperature, dt, friction, hmr_masses, seed)
+    protein_idxs = np.arange(0, len(hmr_masses) - host_config.num_water_atoms, dtype=np.int32)
+    ligand_idxs = np.array([], dtype=np.int32)
+
+    v0 = sample_velocities(hmr_masses, temperature, seed)
+    return InitialState(system.get_U_fns(), intg, baro, x0, v0, host_config.box, 0.0, ligand_idxs, protein_idxs)


### PR DESCRIPTION
* Uses initial states consistently
* Adds option for timestep

## PFKFB3 Performance

Run on an RTX 5090

Looks like there is almost a 50% improvement in throughput going from a 2.5fs to 4fs timestep. 


### 4 femptosecond time step

`python examples/benchmark.py --batch_mode --processes 1 2 4 8 16 24 32 48 --local_md --local_md_steps 390 --system pfkfb3-rbfe --dt_fs 4`

<img width="960" height="720" alt="pfkfb3-rbfe_ns_per_day_2026_Jul_21_09_35_4 0fs" src="https://github.com/user-attachments/assets/bb9ec0c0-070a-4668-aa22-94f84dab87bb" />


### 2.5 femptosecond time step

`python examples/benchmark.py --batch_mode --processes 1 2 4 8 16 24 32 48 --local_md --local_md_steps 390 --system pfkfb3-rbfe`

<img width="960" height="720" alt="pfkfb3-rbfe_ns_per_day_2026_Jul_21_09_40_2 5fs" src="https://github.com/user-attachments/assets/cfac6361-04df-4616-966b-0583293d4a3b" />
