### PR TITLE
rmsf plumbing

### DIFF
--- a/tmd/fe/absolute/free_energy.py
+++ b/tmd/fe/absolute/free_energy.py
@@ -195,7 +195,7 @@ class AbsoluteBindingFreeEnergy(AbsoluteFreeEnergy):
         lig_ids = [i + ligand_offset for i in lig_ids]
 
         # select receptor atoms
-        rec_ids = select_receptor_atoms_baumann(trj, lig_ids, rmsf=rmsf)
+        rec_ids = select_receptor_atoms_baumann(trj, lig_ids, rmsf)
 
         pos = tmtrj.frames[-1]
         box = tmtrj.boxes[-1]

--- a/tmd/fe/absolute/free_energy.py
+++ b/tmd/fe/absolute/free_energy.py
@@ -195,8 +195,7 @@ class AbsoluteBindingFreeEnergy(AbsoluteFreeEnergy):
         lig_ids = [i + ligand_offset for i in lig_ids]
 
         # select receptor atoms
-        # FIXME: reuse the rmsf calculation instead of redoing it in this routine
-        rec_ids = select_receptor_atoms_baumann(trj, lig_ids)
+        rec_ids = select_receptor_atoms_baumann(trj, lig_ids, rmsf=rmsf)
 
         pos = tmtrj.frames[-1]
         box = tmtrj.boxes[-1]

--- a/tmd/fe/absolute/restraints.py
+++ b/tmd/fe/absolute/restraints.py
@@ -47,7 +47,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-import copy
 import itertools
 import tempfile
 from collections.abc import Sequence
@@ -213,13 +212,13 @@ def select_ligand_atoms_baumann(mol: Mol, rmsf: list[float]) -> list[int]:
 def _filter_receptor_atoms(
     trj: mdtraj.Trajectory,
     ligand_ref_idx: int,
+    rmsf: npt.NDArray,
     min_helix_size: int = 8,
     min_sheet_size: int = 8,
     skip_residues_start: int = 20,
     skip_residues_end: int = 10,
     minimum_distance_nm=1.0,
     maximum_distance_nm=3.0,
-    rmsf: npt.NDArray | None = None,
 ) -> list[int]:
     """Select possible protein atoms for Boresch-style restraints.
 
@@ -228,6 +227,8 @@ def _filter_receptor_atoms(
     Args:
         trj: The system trajectory.
         ligand_ref_idx: first restrained ligand atom
+        rmsf: per-atom RMSF (nm) computed against the caller's chosen reference
+            frame, indexed by full-system atom index.
         min_helix_size: The minimum number of residues that have to be in an alpha-helix
             for it to be considered stable.
         min_sheet_size: The minimum number of residues that have to be in a beta-sheet
@@ -286,14 +287,8 @@ def _filter_receptor_atoms(
         raise ValueError("no suitable receptor atoms could be found")
 
     if backbone.n_frames > 1:
-        if rmsf is None: # backcompat
-            superposed = copy.deepcopy(backbone)
-            superposed.superpose(superposed)
-            rmsf_bb = mdtraj.rmsf(superposed, superposed, 0)  # nm
-            rigid_backbone_idxs = rigid_backbone_idxs[rmsf_bb[rigid_backbone_idxs] < _RMSF_CUTOFF]
-        else:
-            full_atom_idxs = backbone_idxs[rigid_backbone_idxs]
-            rigid_backbone_idxs = rigid_backbone_idxs[rmsf[full_atom_idxs] < _RMSF_CUTOFF]
+        full_atom_idxs = backbone_idxs[rigid_backbone_idxs]
+        rigid_backbone_idxs = rigid_backbone_idxs[rmsf[full_atom_idxs] < _RMSF_CUTOFF]
 
     distances = scipy.spatial.distance.cdist(backbone.xyz[0, rigid_backbone_idxs, :], trj.xyz[-1, [ligand_ref_idx], :])
 
@@ -403,7 +398,7 @@ def rdmol_to_mdtraj(mol: Mol) -> mdtraj.Trajectory:
 def select_receptor_atoms_baumann(
     trj: mdtraj.Trajectory,
     ligand_ref_idxs: list[int],
-    rmsf: npt.NDArray | None = None,
+    rmsf: npt.NDArray,
 ) -> list[int]:
     """Select possible protein atoms for Boresch-style restraints.
 
@@ -416,6 +411,8 @@ def select_receptor_atoms_baumann(
     Args:
         trj: The trj containing the receptor and ligands.
         ligand_ref_idxs: The indices of the three ligands atoms that will be restrained.
+        rmsf: per-atom RMSF (nm) computed against the caller's chosen reference
+            frame, indexed by full-system atom index.
 
     Returns:
         The indices of the three atoms to use for the restraint
@@ -423,7 +420,7 @@ def select_receptor_atoms_baumann(
     Raises:
         ValueError: if no suitable receptor atoms could be found
     """
-    receptor_idxs = _filter_receptor_atoms(trj, ligand_ref_idxs[0], rmsf=rmsf)
+    receptor_idxs = _filter_receptor_atoms(trj, ligand_ref_idxs[0], rmsf)
 
     l1, l2, l3 = ligand_ref_idxs
 
@@ -459,6 +456,7 @@ def select_receptor_atoms_baumann(
         r3_distances_prod = r3_distances_avg[:, 0] * r3_distances_avg[:, 1]
         found_r3 = valid_r3_idxs[r3_distances_prod.argmax()]
 
+        print(f"[rec-ids] {[found_r1, found_r2, found_r3]}")
         return [found_r1, found_r2, found_r3]
 
     raise ValueError("could not find a valid R3 atom within max distance")

--- a/tmd/fe/absolute/restraints.py
+++ b/tmd/fe/absolute/restraints.py
@@ -456,7 +456,6 @@ def select_receptor_atoms_baumann(
         r3_distances_prod = r3_distances_avg[:, 0] * r3_distances_avg[:, 1]
         found_r3 = valid_r3_idxs[r3_distances_prod.argmax()]
 
-        print(f"[rec-ids] {[found_r1, found_r2, found_r3]}")
         return [found_r1, found_r2, found_r3]
 
     raise ValueError("could not find a valid R3 atom within max distance")

--- a/tmd/fe/absolute/restraints.py
+++ b/tmd/fe/absolute/restraints.py
@@ -219,6 +219,7 @@ def _filter_receptor_atoms(
     skip_residues_end: int = 10,
     minimum_distance_nm=1.0,
     maximum_distance_nm=3.0,
+    rmsf: npt.NDArray | None = None,
 ) -> list[int]:
     """Select possible protein atoms for Boresch-style restraints.
 
@@ -285,12 +286,14 @@ def _filter_receptor_atoms(
         raise ValueError("no suitable receptor atoms could be found")
 
     if backbone.n_frames > 1:
-        superposed = copy.deepcopy(backbone)
-        superposed.superpose(superposed)
-
-        rmsf = mdtraj.rmsf(superposed, superposed, 0)  # nm
-
-        rigid_backbone_idxs = rigid_backbone_idxs[rmsf[rigid_backbone_idxs] < _RMSF_CUTOFF]
+        if rmsf is None: # backcompat
+            superposed = copy.deepcopy(backbone)
+            superposed.superpose(superposed)
+            rmsf_bb = mdtraj.rmsf(superposed, superposed, 0)  # nm
+            rigid_backbone_idxs = rigid_backbone_idxs[rmsf_bb[rigid_backbone_idxs] < _RMSF_CUTOFF]
+        else:
+            full_atom_idxs = backbone_idxs[rigid_backbone_idxs]
+            rigid_backbone_idxs = rigid_backbone_idxs[rmsf[full_atom_idxs] < _RMSF_CUTOFF]
 
     distances = scipy.spatial.distance.cdist(backbone.xyz[0, rigid_backbone_idxs, :], trj.xyz[-1, [ligand_ref_idx], :])
 
@@ -400,6 +403,7 @@ def rdmol_to_mdtraj(mol: Mol) -> mdtraj.Trajectory:
 def select_receptor_atoms_baumann(
     trj: mdtraj.Trajectory,
     ligand_ref_idxs: list[int],
+    rmsf: npt.NDArray | None = None,
 ) -> list[int]:
     """Select possible protein atoms for Boresch-style restraints.
 
@@ -419,7 +423,7 @@ def select_receptor_atoms_baumann(
     Raises:
         ValueError: if no suitable receptor atoms could be found
     """
-    receptor_idxs = _filter_receptor_atoms(trj, ligand_ref_idxs[0])
+    receptor_idxs = _filter_receptor_atoms(trj, ligand_ref_idxs[0], rmsf=rmsf)
 
     l1, l2, l3 = ligand_ref_idxs
 

--- a/tmd/fe/absolute/restraints.py
+++ b/tmd/fe/absolute/restraints.py
@@ -286,9 +286,8 @@ def _filter_receptor_atoms(
     if len(rigid_backbone_idxs) == 0:
         raise ValueError("no suitable receptor atoms could be found")
 
-    if backbone.n_frames > 1:
-        full_atom_idxs = backbone_idxs[rigid_backbone_idxs]
-        rigid_backbone_idxs = rigid_backbone_idxs[rmsf[full_atom_idxs] < _RMSF_CUTOFF]
+    trj_backbone_idxs = backbone_idxs[rigid_backbone_idxs]
+    rigid_backbone_idxs = rigid_backbone_idxs[rmsf[trj_backbone_idxs] < _RMSF_CUTOFF]
 
     distances = scipy.spatial.distance.cdist(backbone.xyz[0, rigid_backbone_idxs, :], trj.xyz[-1, [ligand_ref_idx], :])
 

--- a/tmd/fe/septop.py
+++ b/tmd/fe/septop.py
@@ -213,7 +213,7 @@ def select_septop_anchors(
 
     # Receptor selection: use ligand A's atom indices in the joint frame; the
     # chosen receptor atoms apply to both ligands since they share the pocket.
-    rec_ids = select_receptor_atoms_baumann(full, [i + n_host for i in lig_ids_a_local])
+    rec_ids = select_receptor_atoms_baumann(full, [i + n_host for i in lig_ids_a_local], rmsf=rmsf)
 
     return SepTopAnchors(
         rec_atoms=list(rec_ids),

--- a/tmd/fe/septop.py
+++ b/tmd/fe/septop.py
@@ -213,7 +213,7 @@ def select_septop_anchors(
 
     # Receptor selection: use ligand A's atom indices in the joint frame; the
     # chosen receptor atoms apply to both ligands since they share the pocket.
-    rec_ids = select_receptor_atoms_baumann(full, [i + n_host for i in lig_ids_a_local], rmsf=rmsf)
+    rec_ids = select_receptor_atoms_baumann(full, [i + n_host for i in lig_ids_a_local], rmsf)
 
     return SepTopAnchors(
         rec_atoms=list(rec_ids),

--- a/tmd/md/smc.py
+++ b/tmd/md/smc.py
@@ -405,7 +405,7 @@ def refine_samples(samples: Samples, log_weights: LogWeights, propagate: BatchPr
 
     # weighted samples -> equally weighted samples
     # TODO: replace multinomial resampling with something less wasteful, like stratified or systematic resampling
-    resample = multinomial_resample  # but not: identity_resample or conditional_multinomial_resample
+    resample = stratified_resample  # but not: identity_resample or conditional_multinomial_resample
     resampled_inds, log_weights = resample(log_weights)
     assert np.isclose(np.std(log_weights), 0), "Need equally weighted samples"
 

--- a/tmd/md/smc.py
+++ b/tmd/md/smc.py
@@ -405,7 +405,7 @@ def refine_samples(samples: Samples, log_weights: LogWeights, propagate: BatchPr
 
     # weighted samples -> equally weighted samples
     # TODO: replace multinomial resampling with something less wasteful, like stratified or systematic resampling
-    resample = stratified_resample  # but not: identity_resample or conditional_multinomial_resample
+    resample = multinomial_resample  # but not: identity_resample or conditional_multinomial_resample
     resampled_inds, log_weights = resample(log_weights)
     assert np.isclose(np.std(log_weights), 0), "Need equally weighted samples"
 


### PR DESCRIPTION
cleanup addressing an existing "TODO" / "FIXME" comments

`tmd/fe/absolute/free_energy.py` and `tmd/fe/septop.py`: thread the already-computed `rmsf` through to `select_receptor_atoms_baumann` with backcompt `rmsf=None` default in restraints.py. resolves the FIXME at free_energy.py and applies the same fix to septop.py. this is a mild behavior change; the RMSF previously computed in `_filter_receptor_atoms` was superposed to frame 0 of a backbone-only slice, whereas the shared `rmsf` is superposed to the backbone of the last frame. so selected receptor atoms may differ. this seems like the more principled choice since ligand and receptor selection now use a consistent reference frame.