### PR TITLE
optional early stopping on legs when converged

### DIFF
--- a/tests/test_hrex_early_stop.py
+++ b/tests/test_hrex_early_stop.py
@@ -1,9 +1,9 @@
 """Unit tests for HREX early-stop plumbing, plus an end-to-end convergence test."""
 
-from dataclasses import dataclass, replace
+from dataclasses import replace
+from types import SimpleNamespace
 
 import numpy as np
-import pytest
 
 from tmd.constants import DEFAULT_TEMP
 from tmd.fe.bar import df_from_ukln_by_lambda
@@ -15,66 +15,22 @@ from tmd.md.hrex import HREXDiagnostics
 from tmd.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
-def _md_params(**overrides):
-    kwargs = dict(n_frames=1000, n_eq_steps=10_000, steps_per_frame=400, seed=2026, hrex_params=HREXParams())
-    kwargs.update(overrides)
-    return MDParams(**kwargs)
-
-
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        dict(early_stop_tol=-0.1),
-        dict(early_stop_tol=0.0),
-        dict(early_stop_tol=0.1, early_stop_check_interval=0),
-        dict(n_frames=100, early_stop_tol=0.1, early_stop_min_frames=101),
-    ],
-)
-def test_early_stop_config_validation_rejects_invalid(kwargs):
-    with pytest.raises(AssertionError):
-        _md_params(**kwargs)
-
-
-def test_early_stop_disabled_by_default():
-    p = _md_params()
-    assert p.early_stop_tol is None
-    # min_frames validation is intentionally skipped when the feature is off.
-    assert _md_params(early_stop_min_frames=999_999).early_stop_min_frames == 999_999
-
-
-@dataclass
-class _FakeInitialState:
-    integrator: object
-
-
-@dataclass
-class _FakeIntegrator:
-    dt: float = 2.5e-3
-
-
-@dataclass
-class _FakePairBarResult:
-    initial_states: list
-
-
-@dataclass
-class _FakeHREXSimulationResult:
-    final_result: _FakePairBarResult
-    hrex_diagnostics: HREXDiagnostics
-    intermediate_results: list
-
-
-def _fake_result(n_windows, diagnostics):
-    states = [_FakeInitialState(_FakeIntegrator()) for _ in range(n_windows)]
-    return _FakeHREXSimulationResult(_FakePairBarResult(states), diagnostics, [])
+def _fake_hrex_result(n_windows, diagnostics):
+    integrator = SimpleNamespace(dt=2.5e-3)
+    states = [SimpleNamespace(integrator=integrator) for _ in range(n_windows)]
+    return SimpleNamespace(
+        final_result=SimpleNamespace(initial_states=states),
+        hrex_diagnostics=diagnostics,
+        intermediate_results=[],
+    )
 
 
 def test_compute_total_ns_uses_recorded_frames_when_present():
-    p = _md_params(n_frames=100)
-    full = compute_total_ns(_fake_result(3, HREXDiagnostics([], [], n_frames_completed=100)), p)
-    half = compute_total_ns(_fake_result(3, HREXDiagnostics([], [], n_frames_completed=50)), p)
+    p = MDParams(n_frames=100, n_eq_steps=10_000, steps_per_frame=400, seed=2026, hrex_params=HREXParams())
+    full = compute_total_ns(_fake_hrex_result(3, HREXDiagnostics([], [], n_frames_completed=100)), p)
+    half = compute_total_ns(_fake_hrex_result(3, HREXDiagnostics([], [], n_frames_completed=50)), p)
     # Fallback path: n_frames_completed=None must behave the same as recording md_params.n_frames.
-    fallback = compute_total_ns(_fake_result(3, HREXDiagnostics([], [], n_frames_completed=None)), p)
+    fallback = compute_total_ns(_fake_hrex_result(3, HREXDiagnostics([], [], n_frames_completed=None)), p)
     assert half < full == fallback
 
 

--- a/tests/test_hrex_early_stop.py
+++ b/tests/test_hrex_early_stop.py
@@ -106,9 +106,8 @@ def test_split_half_bar_distinguishes_converged_from_drifting():
     assert abs(df_a - df_b) > 1.0
 
 
-def test_run_sims_hrex_early_stop_converges_to_same_answer():
-    """End-to-end: early stopping should fire on a real HREX run, and the truncated dG should
-    agree with a full-length reference run (i.e. stopping early doesn't change the answer)."""
+def test_run_sims_hrex_early_stop_terminates_before_budget():
+    """End-to-end: early stop actually fires on a fast-converging real HREX run."""
     lambdas = np.linspace(0.0, 0.1, 4)  # close windows -> high overlap, fast convergence
     forcefield = Forcefield.load_default()
     mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
@@ -126,7 +125,7 @@ def test_run_sims_hrex_early_stop_converges_to_same_answer():
 
     base_params = replace(DEFAULT_HREX_PARAMS, n_frames=500, n_eq_steps=1000, steps_per_frame=100)
 
-    reference_result, _, reference_diagnostics, _ = run_sims_hrex(initial_states, base_params)
+    _, _, reference_diagnostics, _ = run_sims_hrex(initial_states, base_params)
     assert reference_diagnostics.n_frames_completed == base_params.n_frames
 
     early_stop_params = replace(
@@ -135,14 +134,8 @@ def test_run_sims_hrex_early_stop_converges_to_same_answer():
         early_stop_check_interval=10,
         early_stop_min_frames=20,
     )
-    early_stop_result, _, early_stop_diagnostics, _ = run_sims_hrex(initial_states, early_stop_params)
+    _, _, early_stop_diagnostics, _ = run_sims_hrex(initial_states, early_stop_params)
 
-    # Early stop must actually fire well before the full run, i.e. the feature does something.
+    # dG correctness is covered by test_split_half_bar_distinguishes_converged_from_drifting.
     assert early_stop_diagnostics.n_frames_completed is not None
     assert early_stop_diagnostics.n_frames_completed < base_params.n_frames
-
-    # And the truncated estimate must still agree with the fully-converged reference estimate.
-    total_dG_reference = sum(reference_result.dGs)
-    total_dG_early_stop = sum(early_stop_result.dGs)
-    combined_err = np.linalg.norm(reference_result.dG_errs) + np.linalg.norm(early_stop_result.dG_errs)
-    assert abs(total_dG_reference - total_dG_early_stop) < max(5 * combined_err, 1.0)

--- a/tests/test_hrex_early_stop.py
+++ b/tests/test_hrex_early_stop.py
@@ -1,17 +1,18 @@
-"""Unit tests for HREX early-stop plumbing.
+"""Unit tests for HREX early-stop plumbing, plus an end-to-end convergence test."""
 
-End-to-end triggering of early stop is left to integration tests (existing HREX tests with
-early_stop_tol set).
-"""
-
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import numpy as np
 import pytest
 
+from tmd.constants import DEFAULT_TEMP
 from tmd.fe.bar import df_from_ukln_by_lambda
-from tmd.fe.free_energy import HREXParams, MDParams, compute_total_ns
+from tmd.fe.free_energy import HREXParams, MDParams, compute_total_ns, run_sims_hrex
+from tmd.fe.rbfe import DEFAULT_HREX_PARAMS, setup_initial_states
+from tmd.fe.single_topology import SingleTopology
+from tmd.ff import Forcefield
 from tmd.md.hrex import HREXDiagnostics
+from tmd.testsystems.relative import get_hif2a_ligand_pair_single_topology
 
 
 def _md_params(**overrides):
@@ -103,3 +104,45 @@ def test_split_half_bar_distinguishes_converged_from_drifting():
     df_a, _ = df_from_ukln_by_lambda(drifting[..., :half])
     df_b, _ = df_from_ukln_by_lambda(drifting[..., half:])
     assert abs(df_a - df_b) > 1.0
+
+
+def test_run_sims_hrex_early_stop_converges_to_same_answer():
+    """End-to-end: early stopping should fire on a real HREX run, and the truncated dG should
+    agree with a full-length reference run (i.e. stopping early doesn't change the answer)."""
+    lambdas = np.linspace(0.0, 0.1, 4)  # close windows -> high overlap, fast convergence
+    forcefield = Forcefield.load_default()
+    mol_a, mol_b, core = get_hif2a_ligand_pair_single_topology()
+    single_topology = SingleTopology(mol_a, mol_b, core, forcefield)
+
+    initial_states = setup_initial_states(
+        single_topology,
+        None,  # vacuum
+        DEFAULT_TEMP,
+        lambdas,
+        seed=2026,
+        verify_constraints=False,
+        min_cutoff=None,
+    )
+
+    base_params = replace(DEFAULT_HREX_PARAMS, n_frames=500, n_eq_steps=1000, steps_per_frame=100)
+
+    reference_result, _, reference_diagnostics, _ = run_sims_hrex(initial_states, base_params)
+    assert reference_diagnostics.n_frames_completed == base_params.n_frames
+
+    early_stop_params = replace(
+        base_params,
+        early_stop_tol=0.5,
+        early_stop_check_interval=10,
+        early_stop_min_frames=20,
+    )
+    early_stop_result, _, early_stop_diagnostics, _ = run_sims_hrex(initial_states, early_stop_params)
+
+    # Early stop must actually fire well before the full run, i.e. the feature does something.
+    assert early_stop_diagnostics.n_frames_completed is not None
+    assert early_stop_diagnostics.n_frames_completed < base_params.n_frames
+
+    # And the truncated estimate must still agree with the fully-converged reference estimate.
+    total_dG_reference = sum(reference_result.dGs)
+    total_dG_early_stop = sum(early_stop_result.dGs)
+    combined_err = np.linalg.norm(reference_result.dG_errs) + np.linalg.norm(early_stop_result.dG_errs)
+    assert abs(total_dG_reference - total_dG_early_stop) < max(5 * combined_err, 1.0)

--- a/tests/test_hrex_early_stop.py
+++ b/tests/test_hrex_early_stop.py
@@ -1,0 +1,105 @@
+"""Unit tests for HREX early-stop plumbing.
+
+End-to-end triggering of early stop is left to integration tests (existing HREX tests with
+early_stop_tol set).
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from tmd.fe.bar import df_from_ukln_by_lambda
+from tmd.fe.free_energy import HREXParams, MDParams, compute_total_ns
+from tmd.md.hrex import HREXDiagnostics
+
+
+def _md_params(**overrides):
+    kwargs = dict(n_frames=1000, n_eq_steps=10_000, steps_per_frame=400, seed=2026, hrex_params=HREXParams())
+    kwargs.update(overrides)
+    return MDParams(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(early_stop_tol=-0.1),
+        dict(early_stop_tol=0.0),
+        dict(early_stop_tol=0.1, early_stop_check_interval=0),
+        dict(n_frames=100, early_stop_tol=0.1, early_stop_min_frames=101),
+    ],
+)
+def test_early_stop_config_validation_rejects_invalid(kwargs):
+    with pytest.raises(AssertionError):
+        _md_params(**kwargs)
+
+
+def test_early_stop_disabled_by_default():
+    p = _md_params()
+    assert p.early_stop_tol is None
+    # min_frames validation is intentionally skipped when the feature is off.
+    assert _md_params(early_stop_min_frames=999_999).early_stop_min_frames == 999_999
+
+
+@dataclass
+class _FakeInitialState:
+    integrator: object
+
+
+@dataclass
+class _FakeIntegrator:
+    dt: float = 2.5e-3
+
+
+@dataclass
+class _FakePairBarResult:
+    initial_states: list
+
+
+@dataclass
+class _FakeHREXSimulationResult:
+    final_result: _FakePairBarResult
+    hrex_diagnostics: HREXDiagnostics
+    intermediate_results: list
+
+
+def _fake_result(n_windows, diagnostics):
+    states = [_FakeInitialState(_FakeIntegrator()) for _ in range(n_windows)]
+    return _FakeHREXSimulationResult(_FakePairBarResult(states), diagnostics, [])
+
+
+def test_compute_total_ns_uses_recorded_frames_when_present():
+    p = _md_params(n_frames=100)
+    full = compute_total_ns(_fake_result(3, HREXDiagnostics([], [], n_frames_completed=100)), p)
+    half = compute_total_ns(_fake_result(3, HREXDiagnostics([], [], n_frames_completed=50)), p)
+    # Fallback path: n_frames_completed=None must behave the same as recording md_params.n_frames.
+    fallback = compute_total_ns(_fake_result(3, HREXDiagnostics([], [], n_frames_completed=None)), p)
+    assert half < full == fallback
+
+
+def _synthetic_ukln(n_lambda, n_samples, dg_per_pair_kbt, noise, rng):
+    u = np.zeros((n_lambda, 2, 2, n_samples))
+    for i in range(n_lambda):
+        u[i, 0, 1, :] = dg_per_pair_kbt + rng.normal(0, noise, n_samples)
+        u[i, 1, 0, :] = -dg_per_pair_kbt + rng.normal(0, noise, n_samples)
+    return u
+
+
+def test_split_half_bar_distinguishes_converged_from_drifting():
+    rng = np.random.default_rng(0)
+    # Stationary: both halves should agree well within error and match the true dF (4 * 0.5 = 2.0 kBT).
+    stationary = _synthetic_ukln(n_lambda=4, n_samples=2000, dg_per_pair_kbt=0.5, noise=0.05, rng=rng)
+    half = stationary.shape[-1] // 2
+    df_a, err_a = df_from_ukln_by_lambda(stationary[..., :half])
+    df_b, err_b = df_from_ukln_by_lambda(stationary[..., half:])
+    assert abs(df_a - df_b) < 5 * max(err_a, err_b)
+    assert abs(df_a - 2.0) < 0.1 and abs(df_b - 2.0) < 0.1
+
+    # Drifting: dG shifts partway through, halves must disagree by well more than any reasonable tol.
+    first = _synthetic_ukln(n_lambda=4, n_samples=1000, dg_per_pair_kbt=0.0, noise=0.01, rng=rng)
+    second = _synthetic_ukln(n_lambda=4, n_samples=1000, dg_per_pair_kbt=1.0, noise=0.01, rng=rng)
+    drifting = np.concatenate([first, second], axis=-1)
+    half = drifting.shape[-1] // 2
+    df_a, _ = df_from_ukln_by_lambda(drifting[..., :half])
+    df_b, _ = df_from_ukln_by_lambda(drifting[..., half:])
+    assert abs(df_a - df_b) > 1.0

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -2609,12 +2609,6 @@ def run_sims_hrex(
                     print(f"Early stop at frame {n_done}/{md_params.n_frames} ({frames_saved} frames saved)")
                     break
             else:
-                if early_stop_consecutive_passes > 0:
-                    print(
-                        f"Early-stop check @ frame {n_done}: not converged "
-                        f"(|dG diff| = {dg_diff_kcal:.3f}, errs = ({err_a_kcal:.3f}, {err_b_kcal:.3f})) — "
-                        f"resetting pass streak"
-                    )
                 early_stop_consecutive_passes = 0
 
     n_frames_completed = converged_at_frame if converged_at_frame is not None else md_params.n_frames

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -32,6 +32,7 @@ from tmd.fe.bar import (
     bar_with_pessimistic_uncertainty,
     construct_mbar_from_u_kln,
     df_and_err_from_mbar,
+    df_from_ukln_by_lambda,
     pair_overlap_from_mbar,
     sanitize_energies_for_bar,
     works_from_ukln,
@@ -203,12 +204,23 @@ class MDParams:
     water_sampling_params: WaterSamplingParams | None = None
     dt: float = 2.5e-3
 
+    # Setting early_stop_tol to None disables HREX early stopping. Tolerance is in kcal/mol.
+    early_stop_tol: float | None = None
+    early_stop_check_interval: int = 100
+    # Setting early_stop_min_frames to None defaults to max(2, n_frames // 4) at runtime.
+    early_stop_min_frames: int | None = None
+
     def __post_init__(self):
         assert self.steps_per_frame > 0
         assert self.n_frames > 0
         assert self.n_eq_steps >= 0
         if self.local_md_params is not None:
             assert self.local_md_params.local_steps <= self.steps_per_frame
+        if self.early_stop_tol is not None:
+            assert self.early_stop_tol > 0
+            assert self.early_stop_check_interval > 0
+            if self.early_stop_min_frames is not None:
+                assert 0 < self.early_stop_min_frames <= self.n_frames
 
 
 @dataclass
@@ -477,7 +489,14 @@ def compute_total_ns(res: SimulationResult | HREXSimulationResult, md_params: MD
     steps_per_production_frame = md_params.steps_per_frame
     if md_params.hrex_params is not None:
         steps_per_production_frame *= md_params.hrex_params.iterations_per_frame
-    total_steps += steps_per_production_frame * md_params.n_frames * n_windows
+    # Prefer the actual frames completed when early stop truncated the run.
+    n_production_frames = md_params.n_frames
+    hrex_diag = getattr(res, "hrex_diagnostics", None)
+    if hrex_diag is not None:
+        recorded = getattr(hrex_diag, "n_frames_completed", None)
+        if recorded is not None:
+            n_production_frames = recorded
+    total_steps += steps_per_production_frame * n_production_frames * n_windows
 
     dt = res.final_result.initial_states[0].integrator.dt
     dt_in_fs = 1000 * dt
@@ -2447,6 +2466,18 @@ def run_sims_hrex(
 
     inv_kbt = 1 / kBT
 
+    # Split-half convergence check; requires two consecutive passes to guard against noisy crossings.
+    KJ_PER_KCAL = 4.184
+    early_stop_enabled = md_params.early_stop_tol is not None
+    if early_stop_enabled:
+        early_stop_min_frames = md_params.early_stop_min_frames or max(2, md_params.n_frames // 4)
+        early_stop_check_every = md_params.early_stop_check_interval
+        early_stop_tol_kcal = md_params.early_stop_tol
+        early_stop_to_kcal = kBT / KJ_PER_KCAL
+        early_stop_passes_required = 2
+        early_stop_consecutive_passes = 0
+    converged_at_frame: int | None = None
+
     for current_frame in range(md_params.n_frames):
         for i in range(iters_per_frame):
             hrex, samples_by_state_iter, U_kl_raw, water_sampler_proposals_by_state = hrex_func(
@@ -2533,6 +2564,53 @@ def run_sims_hrex(
 
             last_update_time = current_time
 
+        if early_stop_enabled and (current_frame + 1) >= early_stop_min_frames \
+                and (current_frame + 1) % early_stop_check_every == 0:
+            n_done = current_frame + 1
+            n_iters_done = n_done * iters_per_frame
+            half = n_iters_done // 2
+            # Sum across potential components to match the downstream BAR call.
+            ukln_so_far = iterated_u_kln.sum(0)[..., :n_iters_done]
+            df_a, err_a = df_from_ukln_by_lambda(ukln_so_far[..., :half])
+            df_b, err_b = df_from_ukln_by_lambda(ukln_so_far[..., half:])
+            dg_diff_kcal = abs(df_a - df_b) * early_stop_to_kcal
+            err_a_kcal = err_a * early_stop_to_kcal
+            err_b_kcal = err_b * early_stop_to_kcal
+            passed = (
+                dg_diff_kcal < early_stop_tol_kcal
+                and err_a_kcal < early_stop_tol_kcal
+                and err_b_kcal < early_stop_tol_kcal
+            )
+            if passed:
+                early_stop_consecutive_passes += 1
+                print(
+                    f"Early-stop check @ frame {n_done}: "
+                    f"|dG(first half) - dG(second half)| = {dg_diff_kcal:.3f} kcal/mol, "
+                    f"errs = ({err_a_kcal:.3f}, {err_b_kcal:.3f}) — "
+                    f"pass {early_stop_consecutive_passes}/{early_stop_passes_required}"
+                )
+                if early_stop_consecutive_passes >= early_stop_passes_required:
+                    converged_at_frame = n_done
+                    frames_saved = md_params.n_frames - n_done
+                    print(
+                        f"Early stop at frame {n_done}/{md_params.n_frames} "
+                        f"({frames_saved} frames saved)"
+                    )
+                    break
+            else:
+                if early_stop_consecutive_passes > 0:
+                    print(
+                        f"Early-stop check @ frame {n_done}: not converged "
+                        f"(|dG diff| = {dg_diff_kcal:.3f}, errs = ({err_a_kcal:.3f}, {err_b_kcal:.3f})) — "
+                        f"resetting pass streak"
+                    )
+                early_stop_consecutive_passes = 0
+
+    # Truncate off unfilled (np.inf) tail when early stop fired; no-op otherwise.
+    n_frames_completed = converged_at_frame if converged_at_frame is not None else md_params.n_frames
+    n_iters_completed = n_frames_completed * iters_per_frame
+    iterated_u_kln = iterated_u_kln[..., :n_iters_completed]
+
     neighbor_ulkns_by_component = [iterated_u_kln[:, i : i + 2, i : i + 2, :] for i in range(len(initial_states) - 1)]
 
     pair_bar_results = [
@@ -2540,7 +2618,11 @@ def run_sims_hrex(
         for u_kln_by_component in neighbor_ulkns_by_component
     ]
 
-    hrex_diagnostics = HREXDiagnostics(replica_idx_by_state_by_iter, fraction_accepted_by_pair_by_iter)
+    hrex_diagnostics = HREXDiagnostics(
+        replica_idx_by_state_by_iter,
+        fraction_accepted_by_pair_by_iter,
+        n_frames_completed=n_frames_completed,
+    )
     ws_diagnostics: WaterSamplingDiagnostics | None = None
     if md_params.water_sampling_params is not None:
         ws_diagnostics = WaterSamplingDiagnostics(np.array(water_sampler_proposals_by_state_by_iter, dtype=np.int32))

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -2210,6 +2210,9 @@ def run_sequential_hrex_step(
             # Run equilibration as part of the first frame
             n_eq_steps=md_params.n_eq_steps if current_frame == 0 else 0,
             seed=state_idx + current_frame,
+            # Early stop is checked in the outer loop, not per single-frame sample.
+            early_stop_tol=None,
+            early_stop_min_frames=None,
         )
 
         assert md_params_replica.n_frames == 1
@@ -2297,6 +2300,9 @@ def run_batched_hrex_step(
         # Run equilibration as part of the first frame
         n_eq_steps=md_params.n_eq_steps if current_frame == 0 else 0,
         seed=md_params.seed + current_frame,
+        # Early stop is checked in the outer loop, not per single-frame sample.
+        early_stop_tol=None,
+        early_stop_min_frames=None,
     )
 
     assert md_params_replica.n_frames == 1
@@ -2466,7 +2472,6 @@ def run_sims_hrex(
 
     inv_kbt = 1 / kBT
 
-    # Split-half convergence check; requires two consecutive passes to guard against noisy crossings.
     KJ_PER_KCAL = 4.184
     early_stop_enabled = md_params.early_stop_tol is not None
     if early_stop_enabled:
@@ -2474,7 +2479,7 @@ def run_sims_hrex(
         early_stop_check_every = md_params.early_stop_check_interval
         early_stop_tol_kcal = md_params.early_stop_tol
         early_stop_to_kcal = kBT / KJ_PER_KCAL
-        early_stop_passes_required = 2
+        early_stop_passes_required = 2  # guards against a single noisy crossing of the tolerance
         early_stop_consecutive_passes = 0
     converged_at_frame: int | None = None
 
@@ -2564,15 +2569,22 @@ def run_sims_hrex(
 
             last_update_time = current_time
 
-        if early_stop_enabled and (current_frame + 1) >= early_stop_min_frames \
-                and (current_frame + 1) % early_stop_check_every == 0:
+        if (
+            early_stop_enabled
+            and (current_frame + 1) >= early_stop_min_frames
+            and (current_frame + 1) % early_stop_check_every == 0
+        ):
             n_done = current_frame + 1
             n_iters_done = n_done * iters_per_frame
             half = n_iters_done // 2
-            # Sum across potential components to match the downstream BAR call.
+            # df_from_ukln_by_lambda expects neighbor-pair-decomposed [n_lambda, 2, 2, n], matching
+            # neighbor_ulkns_by_component below.
             ukln_so_far = iterated_u_kln.sum(0)[..., :n_iters_done]
-            df_a, err_a = df_from_ukln_by_lambda(ukln_so_far[..., :half])
-            df_b, err_b = df_from_ukln_by_lambda(ukln_so_far[..., half:])
+            neighbor_ukln_so_far = np.stack(
+                [ukln_so_far[i : i + 2, i : i + 2, :] for i in range(len(initial_states) - 1)]
+            )
+            df_a, err_a = df_from_ukln_by_lambda(neighbor_ukln_so_far[..., :half])
+            df_b, err_b = df_from_ukln_by_lambda(neighbor_ukln_so_far[..., half:])
             dg_diff_kcal = abs(df_a - df_b) * early_stop_to_kcal
             err_a_kcal = err_a * early_stop_to_kcal
             err_b_kcal = err_b * early_stop_to_kcal
@@ -2592,10 +2604,7 @@ def run_sims_hrex(
                 if early_stop_consecutive_passes >= early_stop_passes_required:
                     converged_at_frame = n_done
                     frames_saved = md_params.n_frames - n_done
-                    print(
-                        f"Early stop at frame {n_done}/{md_params.n_frames} "
-                        f"({frames_saved} frames saved)"
-                    )
+                    print(f"Early stop at frame {n_done}/{md_params.n_frames} ({frames_saved} frames saved)")
                     break
             else:
                 if early_stop_consecutive_passes > 0:
@@ -2606,7 +2615,6 @@ def run_sims_hrex(
                     )
                 early_stop_consecutive_passes = 0
 
-    # Truncate off unfilled (np.inf) tail when early stop fired; no-op otherwise.
     n_frames_completed = converged_at_frame if converged_at_frame is not None else md_params.n_frames
     n_iters_completed = n_frames_completed * iters_per_frame
     iterated_u_kln = iterated_u_kln[..., :n_iters_completed]

--- a/tmd/fe/free_energy.py
+++ b/tmd/fe/free_energy.py
@@ -2210,7 +2210,8 @@ def run_sequential_hrex_step(
             # Run equilibration as part of the first frame
             n_eq_steps=md_params.n_eq_steps if current_frame == 0 else 0,
             seed=state_idx + current_frame,
-            # Early stop is checked in the outer loop, not per single-frame sample.
+            # Clear early-stop config to avoid tripping the min_frames <= n_frames assertion,
+            # since n_frames is 1 here. Early stop is only checked in the outer run_sims_hrex loop.
             early_stop_tol=None,
             early_stop_min_frames=None,
         )
@@ -2300,7 +2301,8 @@ def run_batched_hrex_step(
         # Run equilibration as part of the first frame
         n_eq_steps=md_params.n_eq_steps if current_frame == 0 else 0,
         seed=md_params.seed + current_frame,
-        # Early stop is checked in the outer loop, not per single-frame sample.
+        # Clear early-stop config to avoid tripping the min_frames <= n_frames assertion,
+        # since n_frames is 1 here. Early stop is only checked in the outer run_sims_hrex loop.
         early_stop_tol=None,
         early_stop_min_frames=None,
     )

--- a/tmd/md/hrex.py
+++ b/tmd/md/hrex.py
@@ -374,7 +374,6 @@ def get_samples_by_iter_by_replica(
 class HREXDiagnostics:
     replica_idx_by_state_by_iter: list[list[ReplicaIdx]]
     fraction_accepted_by_pair_by_iter: list[list[tuple[int, int]]]
-    # None when not recorded (older pickled diagnostics); fall back to md_params.n_frames.
     n_frames_completed: int | None = None
 
     @property

--- a/tmd/md/hrex.py
+++ b/tmd/md/hrex.py
@@ -374,6 +374,8 @@ def get_samples_by_iter_by_replica(
 class HREXDiagnostics:
     replica_idx_by_state_by_iter: list[list[ReplicaIdx]]
     fraction_accepted_by_pair_by_iter: list[list[tuple[int, int]]]
+    # None when not recorded (older pickled diagnostics); fall back to md_params.n_frames.
+    n_frames_completed: int | None = None
 
     @property
     def cumulative_swap_acceptance_rates(self) -> NDArray:


### PR DESCRIPTION
## Summary

Adds optional early stopping to `run_sims_hrex`. When enabled, an HREX leg terminates before its full frame budget if the free-energy estimate has converged, where convergence is determined by input params. Off by default for backward compat.

Three new fields on `MDParams`:

  - `early_stop_tol: float | None = None`: tolerance in kcal/mol.
  - `early_stop_check_interval: int = 100`: frames between convergence checks.
  - `early_stop_min_frames: int | None = None`: floor before checks begin (defaults to `max(2, n_frames // 4)`, which is really arbitrary and i can/will change, i just don't know what the right alternative is).

Every `check_interval` frames (after `min_frames`), the cumulative `iterated_u_kln` is split in half along the sample axis, BAR is run on each half via `df_from_ukln_by_lambda`, and the check passes if the two halves' dGs agree within `tol` and each error is under `tol`. Two consecutive passes required before the loop breaks to catch lucky passes due to noise (is two too arbitrary?).

I'm a little unsure about the time added on by checking for convergence adaptively. I don't think this will be very slow for reasonable checking intervals, but I'm mildly concerned and would appreciate feedback here.

## Testing

I ran the following on GPU and everything passed: `test_hrex_early_stop`, `test_free_energy`, `test_benchmark_free_energy`, `test_hrex_rbfe`, `test_relative_free_energy`, `test_septop`.